### PR TITLE
Citations

### DIFF
--- a/checkDependencies.py
+++ b/checkDependencies.py
@@ -1,6 +1,6 @@
 def checkDependencies():
     try:
-        import numpy, scipy, matplotlib
+        import numpy, scipy, matplotlib, sphinxcontrib.bibtex
         pass
     except Exception, e:
         raise Exception('Requirements not installed, run: "pip install -r requirements.txt" to install requirements')

--- a/conf.py
+++ b/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.bibtex',
     'matplotlib.sphinxext.plot_directive',
 ]
 

--- a/conf.py
+++ b/conf.py
@@ -96,6 +96,8 @@ language = None
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build','_static','AUTHORS.rst','README.md','content/equation_bank/*','content/maxwell1_fundamentals/formative_laws_and_people/*','content/maxwell1_fundamentals/constitutive_relations/*']
 
+nitpick_ignore = [()]
+
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 #default_role = None
@@ -148,7 +150,7 @@ html_theme_options = {
 #html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = 'EM' 
+# html_short_title = 'EM' 
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -386,7 +388,7 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'https://simpeg.readthedocs.org/en/latest/': None}
 
 # -- User Defined Methods ------------------------------------------------
 sys.path.append(os.getcwd())

--- a/content/case_histories/mt_isa/index.rst
+++ b/content/case_histories/mt_isa/index.rst
@@ -19,9 +19,9 @@ This was one of the first examples of inverting DC/IP field data to recover 3D d
     interpretation
     synthesis
 
-**References**
+.. **References**
 
- .. bibliography:: ../../references.bib
-    :style: alpha
-    :encoding: latex+latin
-    :filter: docname in docnames
+..  .. bibliography:: ../../references.bib
+..     :style: alpha
+..     :encoding: latex+latin
+..     :filter: docname in docnames

--- a/content/case_histories/mt_isa/index.rst
+++ b/content/case_histories/mt_isa/index.rst
@@ -3,7 +3,7 @@
 Mt. Isa
 ======= 
 
-This Case History is based upon the paper: 2-D and 3-D IP/resistivity for the interpretation of Isa-style targets by Rutley, Oldenburg and Shekthman [1]_.
+This Case History is based upon the paper: 2-D and 3-D IP/resistivity for the interpretation of Isa-style targets by Rutley, Oldenburg and Shekthman :cite:`rutley2001`.
 
 This was one of the first examples of inverting DC/IP field data to recover 3D distributions of resistivity and chargeability. Before this time the inversion of field data was primarily carried out in 2D. We use this case history is to provide an example for inverting DCR and IP data and make the connecting links to the fundamentals of EM as presented in EM.geosci.xyz.
 
@@ -19,5 +19,9 @@ This was one of the first examples of inverting DC/IP field data to recover 3D d
     interpretation
     synthesis
 
-.. [1] Rutley, A., D.W. Oldenburg and R. Shekhtman, 2001, 2-D and 3-D IP/resistivity inversion for the interpretation of Isa-style targets: Exploration Geophysics, **32**, 156-159
+**References**
 
+ .. bibliography:: ../../references.bib
+    :style: alpha
+    :encoding: latex+latin
+    :filter: docname in docnames

--- a/content/case_histories/mt_isa/setup.rst
+++ b/content/case_histories/mt_isa/setup.rst
@@ -39,9 +39,9 @@ Creek Formation and Eastern Creek Volcanics as shown in :numref:`Geology_Section
 Horizon consists of a sequence of mica schists, phyllites and
 metasiltstones containing gossanous material of coarse grained
 pyrite, pyrrhotite, and magnetite, with variable sphalerite, galena,
-marcasite, chalcopyrite, arsenopyrite and accessories [1]_. Exploration along this horizon has occurred over a 40
+marcasite, chalcopyrite, arsenopyrite and accessories :cite:`russel1978`. Exploration along this horizon has occurred over a 40
 year period. The best drilling intersection recorded is from a 4
-m interval containing 100 g/T Ag, 7.6% Pb and 11.6% Zn [2]_. 
+m interval containing 100 g/T Ag, 7.6% Pb and 11.6% Zn :cite:`poole1981`. 
 
 
 At Mt Isa, copper mineralisation
@@ -50,6 +50,10 @@ the case within the Cluny region. Native Bee Siltstone and
 Moondarra Siltstone are considered to be favourable host
 stratigraphy for mineralisation.
 
-.. [1] Russel, R.R., 1978, The Mount Novit Pb-Ag-Zn Deposit - variations on a Mount Isa theme: Third Australian Geological Convention, Geological Society Australia, **31**, 31
 
-.. [2] Poole, J.R., 1981, A reassessment of the Mount Novit Prospect: unpublished company report.
+**References:**
+
+ .. bibliography:: ../../references.bib
+    :style: alpha
+    :encoding: latex+latin
+    :filter: docname in docnames

--- a/content/case_histories/mt_isa/setup.rst
+++ b/content/case_histories/mt_isa/setup.rst
@@ -51,9 +51,9 @@ Moondarra Siltstone are considered to be favourable host
 stratigraphy for mineralisation.
 
 
-**References:**
+.. **References:**
 
- .. bibliography:: ../../references.bib
-    :style: alpha
-    :encoding: latex+latin
-    :filter: docname in docnames
+..  .. bibliography:: ../../references.bib
+..     :style: alpha
+..     :encoding: latex+latin
+..     :filter: docname in docnames

--- a/content/geophysical_surveys/looploopfdem/data.rst
+++ b/content/geophysical_surveys/looploopfdem/data.rst
@@ -30,9 +30,11 @@ To obtain a datum defined in the frequency domain, a Fourier transform of
 these must be taken. To accomplish this, the time-series is segmented into
 windows, in the case of the Resolve system, 10Hz or 0.1s windows, and a
 discrete Fourier transform of the data in this window is taken to provide a
-single complex number defining the harmonic at the transmitter frequency. This can be done in real-time. [1]_ 
+single complex number defining the harmonic at the transmitter frequency. This can be done in real-time. :cite:`slattery2012` 
 
-Noise: Spheric Pulses (from lightning) -> narrow bandwidth, strong peaks (considered acceptable when < 10 spheric pulses at a given frequency per 100 samples continuously). Monitored separately. [1]_
+Noise: Spheric Pulses (from lightning) -> narrow bandwidth, strong peaks
+(considered acceptable when < 10 spheric pulses at a given frequency per 100
+samples continuously). Monitored separately. :cite:`slattery2012`
 
 Filters: spheric rejection median & Hanning filter
 
@@ -59,4 +61,3 @@ TODO: In-Flight Calibration, bucking coils
 
 TODO: Thibaut's notebook / images
 
-.. [1] Slattery, S.R. and Andriashek, L.D. (2012): Overview of airborne-electromagnetic and -magnetic geophysical survey data collection using the RESOLVE® and GEOTEM® surveys near Red Deer,central Alberta; Energy Resources Conservation Board, ERCB/AGS Open File Report 2012-07, 246 p. Available at: http://www.ags.gov.ab.ca/publications/OFR/PDF/OFR_2012_07.PDF

--- a/content/introduction/introduction_notation.rst
+++ b/content/introduction/introduction_notation.rst
@@ -64,9 +64,9 @@ We also adopt their choice of sign in the Fourier Transform: :math:`e^{i\omega t
 
 
 
-**References** 
+.. **References** 
 
- .. bibliography:: ../references.bib
-    :style: alpha
-    :encoding: latex+latin
-    :filter: docname in docnames
+..  .. bibliography:: ../references.bib
+..     :style: alpha
+..     :encoding: latex+latin
+..     :filter: docname in docnames

--- a/content/introduction/introduction_notation.rst
+++ b/content/introduction/introduction_notation.rst
@@ -67,5 +67,6 @@ We also adopt their choice of sign in the Fourier Transform: :math:`e^{i\omega t
 **References** 
 
  .. bibliography:: ../references.bib
-    :cited: 
-    :style: plain
+    :style: alpha
+    :encoding: latex+latin
+    :filter: docname in docnames

--- a/content/introduction/introduction_notation.rst
+++ b/content/introduction/introduction_notation.rst
@@ -3,7 +3,7 @@
 Notation and Conventions
 ========================
 
-We choose the notation set forth in [Ward_and_Hohmann]_. Their chapter has
+We choose the notation set forth in :cite:`Ward1988`. Their chapter has
 been the foundation of many research papers, is used by geophysicists world-
 wide, and it is clean and unambiguous.
 
@@ -66,4 +66,6 @@ We also adopt their choice of sign in the Fourier Transform: :math:`e^{i\omega t
 
 **References** 
 
-.. [Ward_and_Hohmann] Ward, S. H., & Hohmann, W. (1988). *Electromagnetic Theory for Geophysical Applications Applications.* In Electromagnetic methods in applied geophysics (1st ed., pp. 130–311). Society of Exploration Geophysicists.
+ .. bibliography:: ../references.bib
+    :cited: 
+    :style: plain

--- a/content/introduction/introduction_notation.rst
+++ b/content/introduction/introduction_notation.rst
@@ -3,7 +3,7 @@
 Notation and Conventions
 ========================
 
-We choose the notation set forth in :cite:`Ward1988`. Their chapter has
+We choose the notation set forth in :cite:`ward1988`. Their chapter has
 been the foundation of many research papers, is used by geophysicists world-
 wide, and it is clean and unambiguous.
 

--- a/content/maxwell1_fundamentals/fundamental_laws/ampere_maxwell.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/ampere_maxwell.rst
@@ -315,10 +315,3 @@ of electromagnetic waves as predicated by Maxwell’s electromagnetic theory, an
 demonstrated the equivalence of electromagnetic waves and light.
 
 These efforts have lain solid foundations for the development of modern electromagnetism.
-
-.. **References** 
-
-..  .. bibliography:: ../../references.bib
-..     :style: alpha
-..     :encoding: latex+latin
-..     :filter: docname in docnames

--- a/content/maxwell1_fundamentals/fundamental_laws/ampere_maxwell.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/ampere_maxwell.rst
@@ -296,20 +296,21 @@ Jean-Baptiste Biot and Félix Savart were experimenting with a setup similar to
 Ørsted's experiment (that lead them to define in 1820 a relationship known now
 as the Biot-Savart's law), André-Marie Ampère's experiment focused on
 measuring the forces that two electric wires exert on each other. He
-formulated the Ampere’s circuital law in 1826 [1]_, which relates the magnetic
-field associated with a closed loop to the electric current passing through
-it. In its original form, the current enclosed by the loop only refers to free
-current caused by moving charges, causing several issues regarding the
-conservation of electric charge and the propagation of electromagnetic energy.
+formulated the Ampere’s circuital law in 1826 :cite:`griffiths1999`, which
+relates the magnetic field associated with a closed loop to the electric
+current passing through it. In its original form, the current enclosed by the
+loop only refers to free current caused by moving charges, causing several
+issues regarding the conservation of electric charge and the propagation of
+electromagnetic energy.
 
-In 1861 [2]_, James Clerk Maxwell extended Ampere’s law by introducing the
+In 1861 :cite:`maxwell1861`, James Clerk Maxwell extended Ampere’s law by introducing the
 displacement current into the electric current term to satisfy
 the continuity equation of electric charge. Based on the idea of displacement
-current, in 1864 [3]_, Maxwell established the theory of electromagnetic
+current, in 1864 :cite:`maxwell1865`, Maxwell established the theory of electromagnetic
 field, predicating the wave propagation of electromagnetic fields and the
 equivalence of light propagation and electromagnetic wave propagation.
 
-It was not until the late 1880s [4]_, Heinrich Hertz experimentally proved the existence
+It was not until the late 1880s :cite:`hertz1893`, Heinrich Hertz experimentally proved the existence
 of electromagnetic waves as predicated by Maxwell’s electromagnetic theory, and
 demonstrated the equivalence of electromagnetic waves and light.
 
@@ -319,7 +320,7 @@ These efforts have lain solid foundations for the development of modern electrom
 
 **References**
 
-.. [1] David J. Griffiths. Introduction to electrodynamics, 3rd Edition, Prentice Hall, 1999.
-.. [2] James C. Maxwell. On physical lines of force, part III, the Philosophical Magazine and Journal of Science, 1861.
-.. [3] James C. Maxwell. A dynamical theory of the electromagnetic field, 1864.
-.. [4] Heinrich Hertz. Electric waves: being researches on the propagation of electric action with finite velocity through space, Dover publications, 1893.
+ .. bibliography:: ../../references.bib
+    :style: alpha
+    :encoding: latex+latin
+    :filter: docname in docnames

--- a/content/maxwell1_fundamentals/fundamental_laws/ampere_maxwell.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/ampere_maxwell.rst
@@ -316,11 +316,9 @@ demonstrated the equivalence of electromagnetic waves and light.
 
 These efforts have lain solid foundations for the development of modern electromagnetism.
 
+.. **References** 
 
-
-**References**
-
- .. bibliography:: ../../references.bib
-    :style: alpha
-    :encoding: latex+latin
-    :filter: docname in docnames
+..  .. bibliography:: ../../references.bib
+..     :style: alpha
+..     :encoding: latex+latin
+..     :filter: docname in docnames

--- a/content/maxwell1_fundamentals/fundamental_laws/gauss_electric.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/gauss_electric.rst
@@ -94,7 +94,7 @@ where :math:`\mathbf{F}` is the force between the two charges :math:`q` and :mat
 Having defined Coulomb's law, one might next naturally ask the question how
 would a standard reference charge behave in the presence of any distribution
 of electric charge we might dream up? Answering this question brings us to the
-concept of the electric field. We follow the presentation of [2]_. We can
+concept of the electric field. We follow the presentation of :cite:`griffiths1999`. We can
 define the electric field of an arbitrary charge :math:`Q` as the force
 experienced by a unit charge :math:`q` due to :math:`Q`
 
@@ -159,8 +159,8 @@ simply the charge density :math:`\rho`. This establishes the desired result
 .. math::
    \boldsymbol{\nabla} \cdot \mathbf{e} = \frac{\rho}{\varepsilon_0}.
 
-For a more detailed discussion, see page 36 of [1]_. For an alternate
-derivation and discussion, see pages 65-70 of [2]_.
+For a more detailed discussion, see page 36 of :cite:`fleisch2008`. For an alternate
+derivation and discussion, see pages 65-70 of :cite:`griffiths1999`.
 
 Notes on Electric flux
 ----------------------
@@ -206,9 +206,3 @@ Units
 
   .. math:: 
       \varepsilon_0 = \frac{\text{F}}{\text{m}} = \frac{\text{C}}{\text{V} \cdot \text{m}}.
-
-References
-----------
-.. [1] A student’s guide to Maxwell’s equations (PDF)
-
-.. [2] Griffiths, David J. Introduction to Electrodynamics, 3rd edition. Prentice Hall, Upper Saddle River, New Jersey. 1999.

--- a/content/maxwell1_fundamentals/fundamental_laws/interface_conditions.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/interface_conditions.rst
@@ -41,7 +41,7 @@ In the following derivations, we consider a two layer medium where each layer
 has its corresponding physical properties. In this page, the subindices 1 and
 2 denote dependency on layer 1 and layer 2, respectively. This is illustrated
 in :numref:`twoLayerMedium`. Our derivations follow those presented by
-Griffiths (c.f.  [1]_).
+Griffiths (c.f.  :cite:`griffiths1999`).
 
 .. figure:: images/twoLayerMedium.png
     :align: center
@@ -201,11 +201,6 @@ component of the magnetic field
   
 That is, the tangential component of the magnetic field is discontinuous at
 the interface.
-
-References
-----------
-
-.. [1] Griffiths, David J. Introduction to Electrodynamics, 3rd edition. Prentice Hall, Upper Saddle River, New Jersey. 1999.
 
 
 .. .. rubric:: Footnotes

--- a/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
@@ -49,10 +49,3 @@ linked below provide visual illustrations of Lenz's Law.
 Illustrative Demo:
 `MIT Physics Demo - Lenz's Law with Copper Pipe 
 <http://video.mit.edu/watch/physics-demo-lenzs-law-with-copper-pipe-10268/>`_.
-
-.. **Refereneces** 
-
-..  .. bibliography:: ../../references.bib
-..     :style: alpha
-..     :encoding: latex+latin
-..     :filter: docname in docnames

--- a/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
@@ -56,5 +56,3 @@ Illustrative Demo:
     :style: alpha
     :encoding: latex+latin
     :filter: docname in docnames
-  
-

--- a/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
@@ -28,7 +28,7 @@ by Lenz's Law.
 Lenz's Law states that the induced current will flow in such a direction that
 its secondary or induced magnetic fields act to oppose the  observed change in
 magnetic flux. Simply put, "nature abhors a change in flux" so the induced
-current flows in such a manner to cancel  out the change [Giffiths]_. This is
+current flows in such a manner to cancel  out the change :cite:`griffiths1999`. This is
 the reason for the negative sign in Faraday's Law, equation
 :eq:`faraday_lenz_time`. :numref:`Lenzs_Law_Diagram` and the demonstration
 linked below provide visual illustrations of Lenz's Law.
@@ -52,5 +52,9 @@ Illustrative Demo:
 
 **References** 
 
-.. [Giffiths] Griffiths, David. J (1999). Introduction to Electrodynamics (3rd ed.). Prentice Hall.  
+ .. bibliography:: ../../references.bib
+    :style: alpha
+    :encoding: latex+latin
+    :filter: docname in docnames
+  
 

--- a/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
+++ b/content/maxwell1_fundamentals/fundamental_laws/lenz.rst
@@ -50,9 +50,9 @@ Illustrative Demo:
 `MIT Physics Demo - Lenz's Law with Copper Pipe 
 <http://video.mit.edu/watch/physics-demo-lenzs-law-with-copper-pipe-10268/>`_.
 
-**References** 
+.. **Refereneces** 
 
- .. bibliography:: ../../references.bib
-    :style: alpha
-    :encoding: latex+latin
-    :filter: docname in docnames
+..  .. bibliography:: ../../references.bib
+..     :style: alpha
+..     :encoding: latex+latin
+..     :filter: docname in docnames

--- a/content/maxwell2_steady_state/Maxwell_Discretization.rst
+++ b/content/maxwell2_steady_state/Maxwell_Discretization.rst
@@ -54,7 +54,7 @@ Now let us restrict our attention to three dimensions. There are several ways
 to discretize Maxwell's equations in 3D, including finite difference, finite
 element and finite volume approaches. Here we consider a mimetic finite volume
 approach applied to a uniform grid. For a full description see chapters 3 and
-4 of [1]_. Consider Faraday's law and the quasi-static Ampere's law in the
+4 of :cite:`haber2014`. Consider Faraday's law and the quasi-static Ampere's law in the
 frequency domain
 
 .. math::
@@ -72,7 +72,7 @@ discretizations of Maxwell's equations used in geophysical prospecting apply
 the quasi-static approximation, meaning that they ignore the electric
 displacement term :math:`-i\omega\mathbf{D}` in :ref:`Ampere's law
 <ampere_maxwell>`. In broad terms, ignoring displacement is justified when the
-area of interest is smaller than the source wavelength. See [2]_ for more
+area of interest is smaller than the source wavelength. See :cite:`ward1988` for more
 information.
 
 We divide the earth into a grid of cubic cells. The edges of the grid are
@@ -123,10 +123,4 @@ determine :math:`\tilde{\mathbf{e}}` and :math:`\tilde{\mathbf{b}}`
 simultaneously. We can also combine the two equations to form two smaller
 systems of equations to solve for :math:`\tilde{\mathbf{e}}` and
 :math:`\tilde{\mathbf{b}}` independently.
- 
-References
-----------
 
-.. [1] Haber, Eldad. Computational Methods in Geophysical Electromagnetics. Society for Industrial and Applied Mathematics, Philadelphia, 2015.
-
-.. [2] Ward, Stanley H. and Gerald W. Hohmann. Electromagnetic Theory for Geophysical Applications. In Electromagnetic Methods in Applied Geophysics, Volume 1. Ed. Misac N. Nabighian. Society of Exploration Geophysicists, Tulsa, 1988.

--- a/content/maxwell2_steady_state/SphericalDepression_numerics.rst
+++ b/content/maxwell2_steady_state/SphericalDepression_numerics.rst
@@ -56,7 +56,7 @@ The above resistivity model shows a depressed hemisphere model. The
 resistivity of the depressed hemi-sphere is set to :math:`10^8` ohm-m (close
 to infinity) to simulate air, and the half-space is set to and :math:`10^3`
 ohm-m.  To compute potentials from the above depressed hemi-sphere model, we
-first use numerical solutions using DCIP3D code [1]_. Then to check the
+first use numerical solutions using DCIP3D code :cite:`oldenburg1994`. Then to check the
 accuracy of our numerical algorithm we use analytic solution of a sphere
 problem that we derived in Section :ref:`effecttopo_theory`. For the numerical
 evaluation of that an analytic solution we use :ref:`effecttopo_code`. To
@@ -145,6 +145,3 @@ straight from the positive to negative charges.
 .. |ComparisonSecFineChargs| image:: ./figures/ComparisonSecFineChargs.png
 .. |ComparisonSecFineEfield| image:: ./figures/ComparisonSecFineEfield.png
 
-References
-==========
-.. [1] Oldenburg, D. W. and Li, Y., 1994, Inversion of induced polarization data, Geophysics. 

--- a/content/maxwell2_steady_state/electrostatic_sphere.rst
+++ b/content/maxwell2_steady_state/electrostatic_sphere.rst
@@ -9,7 +9,7 @@ problems. Here we examine the case of a conducting sphere in a uniform
 electrostatic field. This scenario gives us a setting to examine aspects of
 the DC resistivity experiment, including the behavior of electric potentials,
 electric fields, current density and the build up of charges at interfaces.
-This work follows the derivation in [1]_ and is supported by apps developed in
+This work follows the derivation in :cite:`ward1988` and is supported by apps developed in
 a `Jupyter Notebook`_.
 
 .. _Jupyter Notebook: https://github.com/ubcgif/em/blob/AmpereMaxwell/examples/sphere/ElectrostaticSphere.ipynb
@@ -437,6 +437,3 @@ The only parameters that have changed are the radius and the conductivity of the
     inversion_uncertainty(XYZ,sig0,sig1,sig2,R0,R1,E0,xstart,ystart,xend,yend,nb_dipole,electrode_spacing,PlotOpt)
     plt.show()
 
-
-
-.. [1] Ward, S. H., & Hohmann, W. *Electromagnetic Theory for Geophysical Applications Applications.* In Electromagnetic methods in applied geophysics (1st ed., pp. 130–311). Society of Exploration Geophysicists. 1988.

--- a/content/references.bib
+++ b/content/references.bib
@@ -24,3 +24,10 @@
   publisher={Australian Society of Exploration Geophysicists (ASEG) PO Box 8463, Perth Business Centre WA 6849 Australia}
 }
 
+@misc{griffiths1999,
+  title={Introduction to electrodynamics},
+  author={Griffiths, David J},
+  year={1999},
+  publisher={Prentice-Hall}
+}
+

--- a/content/references.bib
+++ b/content/references.bib
@@ -13,3 +13,14 @@
     year = {1988}
 }
 
+@article{rutley2001,
+  title={2-D and 3-D IP/resistivity inversion for the interpretation of Isa-style targets},
+  author={Rutley, Andrea and Oldenburg, Douglas W and Shekhtman, Roman},
+  journal={Exploration Geophysics},
+  volume={32},
+  number={3/4},
+  pages={156--159},
+  year={2001},
+  publisher={Australian Society of Exploration Geophysicists (ASEG) PO Box 8463, Perth Business Centre WA 6849 Australia}
+}
+

--- a/content/references.bib
+++ b/content/references.bib
@@ -1,0 +1,15 @@
+@incollection{Ward1988,
+    author = {Ward, Stanley H and Hohmann, Gerald W},
+    booktitle = {Electromagnetic Methods in Applied Geophysics},
+    chapter = {4},
+    doi = {10.1190/1.9781560802631.ch4},
+    edition = {1},
+    file = {:Users/lindseyjh/git/Library/Ward, Hohmann - 1988 - Electromagnetic Theory for Geophysical Applications Applications.pdf:pdf},
+    mendeley-groups = {General EM,ThesisProposal},
+    pages = {130--311},
+    publisher = {Society of Exploration Geophysicists},
+    title = {{Electromagnetic Theory for Geophysical Applications}},
+    url = {http://library.seg.org/doi/abs/10.1190/1.9781560802631.ch4},
+    year = {1988}
+}
+

--- a/content/references.bib
+++ b/content/references.bib
@@ -1,4 +1,4 @@
-@incollection{Ward1988,
+@incollection{ward1988,
     author = {Ward, Stanley H and Hohmann, Gerald W},
     booktitle = {Electromagnetic Methods in Applied Geophysics},
     chapter = {4},
@@ -24,10 +24,49 @@
   publisher={Australian Society of Exploration Geophysicists (ASEG) PO Box 8463, Perth Business Centre WA 6849 Australia}
 }
 
-@misc{griffiths1999,
+@book{griffiths1999,
   title={Introduction to electrodynamics},
   author={Griffiths, David J},
   year={1999},
   publisher={Prentice-Hall}
+}
+
+@misc{poole1981,
+    title={A reassessment of the Mount Novit Prospect: unpublished company report},
+    author={Poole, J.R.},
+    year={1981}
+}
+
+@article{russel1978,
+    title={The Mount Novit Pb-Ag-Zn Deposit - variations on a Mount Isa theme},
+    author={Russel, R.R.},
+    year={1978},
+    journal={Third Australian Geological Convention, Geological Society Australia},
+    volume={31},
+}
+
+@book{hertz1893,
+  title={Electric waves: being researches on the propagation of electric action with finite velocity through space},
+  author={Hertz, Heinrich},
+  year={1893},
+  publisher={Dover Publications}
+}
+
+@article{maxwell1861,
+  title={XLIV. On physical lines of force},
+  author={Maxwell, James C},
+  journal={The London, Edinburgh, and Dublin Philosophical Magazine and Journal of Science},
+  volume={21},
+  number={140},
+  pages={281--291},
+  year={1861},
+  publisher={Taylor \& Francis}
+}
+
+@book{maxwell1865,
+  author={James C. Maxwell},
+  title={A dynamical theory of the electromagnetic field}, 
+  year={1865},
+  publisher={Philosophical Transactions of the Royal Society}
 }
 

--- a/content/references.bib
+++ b/content/references.bib
@@ -70,3 +70,37 @@
   publisher={Philosophical Transactions of the Royal Society}
 }
 
+@misc{slattery2012,
+  author={Slattery, S.R. and Andriashek, L.D.},
+  year={2012},
+  title={Overview of airborne-electromagnetic and -magnetic geophysical survey data collection using the RESOLVE® and GEOTEM® surveys near Red Deer,central Alberta, ERCB/AGS Open File Report 2012-07 },
+  publisher={Energy Resources Conservation Board}, 
+  pages={246},
+  url={http://www.ags.gov.ab.ca/publications/OFR/PDF/OFR_2012_07.PDF}
+}
+
+@book{fleisch2008,
+  title={A Student's guide to Maxwell's equations},
+  author={Fleisch, Daniel},
+  year={2008},
+  publisher={Cambridge University Press}
+}
+
+@book{haber2014,
+  title={Computational Methods in Geophysical Electromagnetics},
+  author={Haber, Eldad},
+  volume={1},
+  year={2014},
+  publisher={SIAM}
+}
+
+@article{oldenburg1994,
+  title={Inversion of induced polarization data},
+  author={Oldenburg, Douglas W and Li, Yaoguo},
+  journal={Geophysics},
+  volume={59},
+  number={9},
+  pages={1327--1341},
+  year={1994},
+  publisher={Society of Exploration Geophysicists}
+}

--- a/content/references.rst
+++ b/content/references.rst
@@ -1,0 +1,9 @@
+.. _references:
+
+References
+==========
+
+ .. bibliography:: references.bib
+    :all:
+    :style: alpha
+    :encoding: latex+latin

--- a/index.rst
+++ b/index.rst
@@ -33,7 +33,7 @@ experts, worldwide, contribute. Join the development on github_.
 **Contents:**
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
    :name: `EM GeoSci`
 
    content/introduction/index
@@ -44,6 +44,7 @@ experts, worldwide, contribute. Join the development on github_.
    content/maxwell4_tdem/index
    content/geophysical_surveys/index
    content/case_histories/index
+   content/references
 
 
 Contributors:
@@ -52,10 +53,4 @@ Contributors:
 .. include:: AUTHORS.rst
 
 
-.. Indices and tables
-.. ==================
-
-.. * :ref:`genindex`
-.. * :ref:`modindex`
-.. * :ref:`search`
 

--- a/index.rst
+++ b/index.rst
@@ -33,7 +33,7 @@ experts, worldwide, contribute. Join the development on github_.
 **Contents:**
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 3
    :name: `EM GeoSci`
 
    content/introduction/index

--- a/index.rst
+++ b/index.rst
@@ -30,7 +30,14 @@ experts, worldwide, contribute. Join the development on github_.
 
 .. _github: https://github.com/ubcgif/em
 
-**Contents:**
+Contributors:
+-------------
+
+.. include:: AUTHORS.rst
+
+
+Contents:
+---------
 
 .. toctree::
    :maxdepth: 3
@@ -47,10 +54,7 @@ experts, worldwide, contribute. Join the development on github_.
    content/references
 
 
-Contributors:
--------------
 
-.. include:: AUTHORS.rst
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 matplotlib
+sphinxcontrib-bibtex


### PR DESCRIPTION
- using sphinxcontrib-bibtex for bibtex citations : requires that you `pip install sphinxcontrib-bibtex`
- bibtex citations are stored in references.bib (using `authorYEAR` for cite-keys - lower case author)
- citing inline is `:cite:citekey`
- a single, global bibliography is generated in the page references.rst