### PR TITLE
add link from mt isa page to linkcheck ignore

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -99,6 +99,7 @@ exclude_patterns = ['_build','_static','AUTHORS.rst','README.md','content/equati
 linkcheck_ignore = ['http://mybinder.org/repo/ubcgif/em_examples',
                     'http://www.austhaigeophysics.com/A%20Comparison%20of%202D%20and%203D%20IP%20from%20Copper%20Hill%20NSW%20-%20Extended%20Abstract.pdf',
                     'http://scitation.aip.org/content/aip/journal/jcp/9/4/10.1063/1.1750906',
+                    'http://www.ga.gov.au/metadata-gateway/metadata/record/gcat_aac46307-fce8-449d-e044-00144fdd4fa6/',
                     ]
 
 # The reST default role (used for this markup: `text`) to use for all


### PR DESCRIPTION
Added a slow-loading page to the linkcheck ignore (http://www.ga.gov.au/metadata-gateway/metadata/record/gcat_aac46307-fce8-449d-e044-00144fdd4fa6/)

