### PR TITLE
don't load simpeg docs with intersphinx

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -464,7 +464,7 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://simpeg.readthedocs.org/en/latest/': None}
+# intersphinx_mapping = {'https://simpeg.readthedocs.org/en/latest/': None}
 
 # -- User Defined Methods ------------------------------------------------
 sys.path.append(os.getcwd())


### PR DESCRIPTION
don't load simpeg documentation into namespace. we do not reference it, and now that the docs have moved, the read the docs link no longer exists 