### PR TITLE
add contributors.json

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -1,0 +1,18 @@
+{
+    "lheagy":{
+        "name":"Lindsey J. Heagy",
+        "affiliation":"University of British Columbia",
+        "location":"Vancouver, BC",
+        "email":"lheagy@eos.ubc.ca",
+        "url":"http://lindseyjh.ca",
+        "tooltip":"https://avatars.githubusercontent.com/u/6361812?v=3",
+        "ORCID":"0000-0002-1551-5926"
+    },
+    "simpegbot":{
+        "name":"SimPEG bot",
+        "affiliation":"SimPEG",
+        "location":"The Web",
+        "url":"http://simpeg.xyz",
+        "tooltip":"./img/simpegbot.png"
+    }
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+if __name__ == '__main__':
+    import os
+    import glob
+    import unittest
+    test_file_strings = glob.glob('test_*.py')
+    module_strings = [str[0:len(str)-3] for str in test_file_strings]
+    suites = [unittest.defaultTestLoader.loadTestsFromName(str) for str
+              in module_strings]
+    testSuite = unittest.TestSuite(suites)
+
+    unittest.TextTestRunner(verbosity=2).run(testSuite)

--- a/tests/test_contributorsjson.py
+++ b/tests/test_contributorsjson.py
@@ -1,0 +1,29 @@
+import subprocess
+import unittest
+import os
+import json
+
+PATH2JSON = '..'
+
+class ContribsJson_Test(unittest.TestCase):
+
+    def test_contributorsjson(self):
+
+        print '\nTesting contributors.json validity'
+
+        contribsjson = os.path.sep.join([PATH2JSON] + ['contributors.json'])
+        contribs = open(contribsjson)
+
+        try:
+            json.load(contribs)
+
+        except Exception as err:
+            print("<<<<< FAILED: contributors.json invalid >>>>> \n Error: {0}".format(err))
+            raise
+
+        print '... ok'
+        return True
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_contributorsjson.py
+++ b/tests/test_contributorsjson.py
@@ -11,7 +11,7 @@ class ContribsJson_Test(unittest.TestCase):
 
         print '\nTesting contributors.json validity'
 
-        contribsjson = os.path.sep.join([PATH2JSON] + ['contributors.json'])
+        contribsjson = os.path.abspath(os.path.sep.join([PATH2JSON] + ['contributors.json']))
         contribs = open(contribsjson)
 
         try:

--- a/tests/test_contributorsjson.py
+++ b/tests/test_contributorsjson.py
@@ -3,7 +3,6 @@ import unittest
 import os
 import json
 
-PATH2JSON = '..'
 
 class ContribsJson_Test(unittest.TestCase):
 
@@ -11,7 +10,10 @@ class ContribsJson_Test(unittest.TestCase):
 
         print '\nTesting contributors.json validity'
 
-        contribsjson = os.path.abspath(os.path.sep.join([PATH2JSON] + ['contributors.json']))
+        dirname, filename = os.path.split(os.path.abspath(__file__))
+        path2json = os.path.sep.join(dirname.split(os.path.sep)[:-1])
+
+        contribsjson = os.path.abspath(os.path.sep.join([path2json] + ['contributors.json']))
         contribs = open(contribsjson)
 
         try:


### PR DESCRIPTION
Added the file [contributors.json](https://github.com/ubcgif/em/compare/contributors?expand=1#diff-22d8fa9ed2a4c0de7ce6873baf2db61dR1) which contains information on contributors. 

<img width="927" alt="contributors json sphinxcontrib-contributors 2016-06-29 13-03-24" src="https://cloud.githubusercontent.com/assets/6361812/16467056/6e4ab986-3dfa-11e6-814e-30da57d33071.png">

- Please copy-paste the "lheagy" entry and replace it with your own information. All id's must be unique and contain no spaces or special characters. Using your github id is a good idea. 
- If there are entries which you do not wish to include (eg. ORCID) remove it from the list. 
- To check that you have properly entered your information go into the `tests` folder and run ` python test_contributorsjson.py`

Inside the specific rst folders, to add contributor information please add 
```
.. {"Authors": ["id1", "id2"], "Reviewers": ["id3", "id4"]}
```
to the top of the rst folder, replacing the "idx" with the userid in contributors.json. The order of authors will be preserved, so please decide amongst the contributing parties what the order should be. 