### PR TITLE
use http://simpeg.xyz (not www.simpeg.xyz - this is redirected)

### DIFF
--- a/content/case_histories/mt_isa/survey.rst
+++ b/content/case_histories/mt_isa/survey.rst
@@ -66,7 +66,7 @@ problem arise in the :ref:`next chapter <mt_isa_data_ip>`.
 
    *  - .. raw:: html
             :file: ./images/Mt_Isa_Current_Anim.html
-   *  - Conductivity model (color) and current flow (arrows) for a range of source locations (Powered by: `SimPEG <http://www.simpeg.xyz/>`_).
+   *  - Conductivity model (color) and current flow (arrows) for a range of source locations (Powered by: `SimPEG <http://simpeg.xyz/>`_).
 
 
 


### PR DESCRIPTION
patch - use http://simpeg.xyz instead of http://www.simpeg.xyz which is redirected to http://simpeg.xyz

This makes the link-check test more stable 