### PR TITLE
add html widget from gpg

### DIFF
--- a/content/geophysical_surveys/dcr/data.rst
+++ b/content/geophysical_surveys/dcr/data.rst
@@ -9,8 +9,18 @@ Data
 
 .. _dcr_pseudosection:
 
+Soundings
+---------
+
+.. raw:: html
+    :file: images/sounding_radio_buttons.html
+
+
 Pseudo-section
 --------------
+
+.. raw:: html
+    :file: images/pseudosection_radio_buttons.html
 
 The layout shown in {figure} indicates
 a current electrode at postion 1 with potentials measured across all other
@@ -32,3 +42,4 @@ pole on the right as seen in :numref:`Pseudo_PDP_West`.
     :name: Pseudo_PDP_West
 
     Data for pole moving west to east.
+

--- a/content/geophysical_surveys/dcr/images/physics_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/physics_radio_buttons.html
@@ -30,7 +30,6 @@ function MM_preloadImages() { //v3.0
     var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
     if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
 }
-MM_preloadImages('./../../_images/t1.gif','./../../_images/t2.gif','./../../_images/t3.gif','./../../_images/t4.gif','./../../_images/t5.gif','./../../_images/t6.gif','./../../_images/t7.gif','./../../_images/t8.gif','./../../_images/t9.gif','./../../_images/t10.gif','./../../_images/t11.gif','./../../_images/t12.gif','./../../_images/t13.gif','./../../_images/shell.gif','./../../_images/s1.gif','./../../_images/s2.gif','./../../_images/s3.gif','./../../_images/s4.gif','./../../_images/s5.gif','./../../_images/s6.gif','./../../_images/s7.gif','./../../_images/s8.gif','./../../_images/s9.gif','./../../_images/s10.gif','./../../_images/s11.gif','./../../_images/s12.gif','./../../_images/s13.gif','./../../_images/s14.gif','./../../_images/s15.gif','./../../_images/s16.gif','./../../_images/e1.gif','./../../_images/e2.gif','./../../_images/e3.gif','./../../_images/e4.gif','./../../_images/e5.gif','./../../_images/e6.gif','./../../_images/e7.gif','./../../_images/e8.gif','./../../_images/e9.gif','./../../_images/e10.gif','./../../_images/e11.gif','./../../_images/e12.gif','./../../_images/e13.gif','./../../_images/e14.gif','./../../_images/e15.gif','./../../_images/e16.gif');
 </script>
 
             <table cellspacing="0" width="100%">

--- a/content/geophysical_surveys/dcr/images/pseudosection_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/pseudosection_radio_buttons.html
@@ -1,0 +1,51 @@
+<script language="JavaScript" type="text/JavaScript">
+
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_findObj(n, d) { //v4.01
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document);
+  if(!x && d.getElementById) x=d.getElementById(n); return x;
+}
+
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+
+
+function MM_preloadImages() { //v3.0
+  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+
+// MM_preloadImages('./../../_images/t1.gif','./../../_images/t2.gif','./../../_images/t3.gif','./../../_images/t4.gif','./../../_images/t5.gif','./../../_images/t6.gif','./../../_images/t7.gif','./../../_images/t8.gif','./../../_images/t9.gif','./../../_images/t10.gif','./../../_images/t11.gif','./../../_images/t12.gif','./../../_images/t13.gif','./../../_images/shell.gif','./../../_images/s1.gif','./../../_images/s2.gif','./../../_images/s3.gif','./../../_images/s4.gif','./../../_images/s5.gif','./../../_images/s6.gif','./../../_images/s7.gif','./../../_images/s8.gif','./../../_images/s9.gif','./../../_images/s10.gif','./../../_images/s11.gif','./../../_images/s12.gif','./../../_images/s13.gif','./../../_images/s14.gif','./../../_images/s15.gif','./../../_images/s16.gif','./../../_images/e1.gif','./../../_images/e2.gif','./../../_images/e3.gif','./../../_images/e4.gif','./../../_images/e5.gif','./../../_images/e6.gif','./../../_images/e7.gif','./../../_images/e8.gif','./../../_images/e9.gif','./../../_images/e10.gif','./../../_images/e11.gif','./../../_images/e12.gif','./../../_images/e13.gif','./../../_images/e14.gif','./../../_images/e15.gif','./../../_images/e16.gif')
+</script>
+
+
+            <table align="center" cellpadding="4" cellspacing="0" width="100%">
+              <tbody>
+
+                <tr>
+                  <td valign="top" style="width:30%;">
+                   <!--  <table align="left" border="1" cellpadding="1" cellspacing="0" width="100%">
+                      <tbody> -->
+                        <tr valign="top">
+                          <td>
+                            <br>
+                            <input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('pseudoanim','','http://gpg.geosci.xyz/en/latest/_images/lawn-ps.gif',1)" type="radio">
+                            Display the finished contoured pseudosection.<br>
+                            <input name="radiobutton" value="radiobutton" checked="checked"  onclick="MM_swapImage('pseudoanim','','http://gpg.geosci.xyz/en/latest/_images/pseudo-anim.gif',1)" checked="checked" type="radio">
+                            Return to the animation. <br>
+                          </td>
+                      </td>
+                      <td style="width:70%;">
+                        <img src="http://gpg.geosci.xyz/en/latest/_images/pseudo-anim.gif" name="pseudoanim" alt="profiling concepts" border="0" width="100%"><br>
+                      </td>
+                </tr>
+              </tbody>
+            </table>

--- a/content/geophysical_surveys/dcr/images/sounding_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/sounding_radio_buttons.html
@@ -1,0 +1,74 @@
+<script language="JavaScript" type="text/JavaScript">
+
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_findObj(n, d) { //v4.01
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document);
+  if(!x && d.getElementById) x=d.getElementById(n); return x;
+}
+
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+
+function MM_preloadImages() { //v3.0
+  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+}
+
+</script>
+
+
+        <table border="0" cellpadding="1" cellspacing="0" width="100%">
+          <tbody>
+<!--             <tr valign="top">
+              <td colspan="2" valign="top"> <div class="caption">
+                Figure 8.
+
+                Therefore, data must be plotted as a function of electrode
+                spacing rather than as a function of location. The resulting
+                plot is called a sounding curve, and it arises as shown in
+                this interactive figure (Figure 8). Only current electrodes
+                are shown. Potentials would be measured inside current
+                electrodes using either the Wenner or Schulmberger
+                configurations.
+
+              </div></td>
+            </tr> -->
+            <tr>
+              <td valign="top" style="width:65%;">
+                  <table align="center" border="1" cellpadding="2" cellspacing="0" width="100%">
+                      <tbody>
+                        <tr valign="top">
+                          <td>
+                            <br>
+                            <input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv1.gif',1)" type="radio">
+                              &nbsp At small electrode spacings current flows only in near-surface regions. Apparent resistivities look similar to the true resistivity of overburden.
+                              <br><br>
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv2.gif',1)" type="radio">
+                              &nbsp As current flows deeper, apparent resistivities are influenced by the true resistivities of deeper materials.<br><br>
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv3.gif',1)" type="radio">
+                              &nbsp The sounding curve begins to indicate that there are at least 2 layers under this location.<br><br>
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv4.gif',1)" type="radio">
+                              &nbsp At very large electrode spacings most of the information reflects deeper ground because that is where most of the current is flowing.<br><br>
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv5.gif',1)" type="radio">
+                              &nbsp The completed sounding curve. <br><br>
+                          </td>
+
+                          <td style="width:35%;"><img src="http://gpg.geosci.xyz/en/latest/_images/surv1.gif" name="sounding" width="100%">
+                          <br>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table><br>
+                </td>
+              </tr>
+            </tbody>
+        </table>

--- a/content/geophysical_surveys/dcr/images/survey_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/survey_radio_buttons.html
@@ -1,0 +1,98 @@
+<script language="JavaScript" type="text/JavaScript">
+<!--
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_findObj(n, d) { //v4.01
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document);
+  if(!x && d.getElementById) x=d.getElementById(n); return x;
+}
+
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+
+function MM_preloadImages() { //v3.0
+  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+}
+
+</script>
+
+
+ <table border="1" cellpadding="1" cellspacing="1" width="100%">
+          <tbody>
+            <tr>
+              <td><font size="-1"><img src="http://gpg.geosci.xyz/en/latest/_images/add1.gif" name="arrays" align="middle" height="74" width="300"> </font> <span class="caption">Figure 7. DC resistivity arrays </span>
+                <form name="form1" method="post" action="">
+                  <table align="center" border="1" cellpadding="2" cellspacing="0" width="98%">
+                    <tbody>
+                      <tr valign="top">
+                        <td><strong>a.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/add1.gif',1)" type="radio"></td>
+                        <td rowspan="2"><b>dipole-dipole (dpdp)</b></td>
+                        <td> Most common profiling configuration. </td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>b.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/add2.gif',1)" type="radio"></td>
+                        <td>Several potential measurements are taken for each transmitter station.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>c.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/apd.gif',1)" type="radio"></td>
+                        <td><b>pole-dipole (pldp)</b></td>
+                        <td> Compared to dpdp, more efficient (move only one source electrode), deeper penetration, but lower spatial resolution.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>d.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/app.gif',1)" type="radio"></td>
+                        <td><strong>pole-pole (plpl)</strong></td>
+                        <td> Compared to pldp, more efficient, deeper penetration, but lower spatial resolution.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>e.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/ag.gif',1)" type="radio"></td>
+                        <td><b>gradient array</b></td>
+                        <td> Poor depth information but rapid reconnaissance of large areas.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>f.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/ar.gif',1)" type="radio"></td>
+                        <td><b>Real section</b></td>
+                        <td> Potential electrodes move along lines between current source electrodes.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>g.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/as1.gif',1)" type="radio"></td>
+                        <td rowspan="2"><b>Schlumberger sounding </b></td>
+                        <td> Distance "a" is on the order of one tenth of distance "b".</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>h.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/as2.gif',1)" type="radio"></td>
+                        <td>For soundings, "b" can remain unchanged, as long as a &lt;&lt; b, and measured potentials are strong enough to record.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>i.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/aw1.gif',1)" type="radio"></td>
+                        <td rowspan="2"><b>Wenner sounding </b></td>
+                        <td> The three spacings between electrodes are kept equal for all measurements.</td>
+                      </tr>
+                      <tr valign="top">
+                        <td><strong>j.</strong></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/aw2.gif',1)" type="radio"></td>
+                        <td>For soundings all electrodes must be moved for each new datum.</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </form></td>
+            </tr>
+          </tbody>
+        </table>

--- a/content/geophysical_surveys/dcr/physics.rst
+++ b/content/geophysical_surveys/dcr/physics.rst
@@ -15,14 +15,14 @@ interfaces, which change the electric potentials that are measured on the
 surface.
 
 .. raw:: html
-    :file: figure2.html
+    :file: images/physics_radio_buttons.html
 
 We illustrate the DCR experiment with a synthetic pole-dipole survey as
 illustrated in :numref:`DCR_TwoSpheres`. This simple
 :ref:`conductivity<electrical_conductivity_index>` model is made up of two
 spheres in a uniform half-space Earth. Currents are injected into the ground
 from the source, and potentials are measured at different locations. Using
-:ref:`numerical methods<solving_maxwells_equations>`, we can model the currents 
+:ref:`numerical methods<solving_maxwells_equations>`, we can model the currents
 and accumulation of charges due to conductivity contrasts as shown in the
 animation below. The arrows denote the :ref:`current
 density<current_density_J>`, while the color indicates the strength and sign
@@ -47,7 +47,7 @@ Conversely, current lines get deflected around the resistor.
 conductivity contrasts. Note the difference in polarity between
 the conductive and resistive anomaly as predicted by the :ref:`theory<bound_charge_Q>`.
 Also note how the spatial distribution of charges on the spheres changes
-as the current source is moved. 
+as the current source is moved.
 
  .. raw:: html
     :file: images/TwoSphere_Current_Anim.html

--- a/content/geophysical_surveys/dcr/survey.rst
+++ b/content/geophysical_surveys/dcr/survey.rst
@@ -11,6 +11,10 @@ Survey
 Basic Survey Setup
 ------------------
 
+.. raw:: html
+   :file: images/survey_radio_buttons.html
+
+
 **Pole-dipole**: A DC/IP survey using a single current electrode (the second current electrode
 is at "infinity" or many kilometers away from the nearest receiver electrode)
 and two potential electrodes. Conventionally, for a 2D survey the receiver
@@ -156,5 +160,4 @@ DC/IP survey with a copper sulphate solution is shown in
    :name: porous_pot_receiver
 
    A single porous pot electrode in the ground connected to a receiver.
-
 


### PR DESCRIPTION
add html widgets from the gpg including
- /geophysical_surveys/dcr/images/physics_radio_button.html (figure 2 originally from: http://gpg.geosci.xyz/en/latest/content/DC_resistivity/DC_measurements_and_data.html#current-flow-in-the-ground) added to physics.rst
- /geophysical_surveys/dcr/images/sounding_radio_buttons.html (figure 8 from http://gpg.geosci.xyz/en/latest/content/DC_resistivity/DC_measurements_and_data.html#survey-configurations) added to data.rst
- /geophysical_surveys/dcr/images/sounding_radio_buttons.html (figure 10 from: http://gpg.geosci.xyz/en/latest/content/DC_resistivity/DC_measurements_and_data.html#profiling) added to data.rst

to include use: 
```
.. raw:: html
   :file: images/survey_radio_buttons.html
```

![image](https://cloud.githubusercontent.com/assets/6361812/17688729/ae8723c0-6336-11e6-911c-f5b8cfffd347.png)

@micmitch , @sdevriese , @fourndo 