### PR TITLE
point to updated location of dc code in em_examples

### DIFF
--- a/content/geophysical_surveys/dcr/images/physics_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/physics_radio_buttons.html
@@ -40,42 +40,42 @@ function MM_preloadImages() { //v3.0
                 <tr>
                   <td valign="top" width="10"><font size="-1"><b>a. </b> </font></td>
                   <td valign="top" width="10"><font size="-1">
-                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/en/latest/_images/elura1.jpg',1)" checked="checked" type="radio">
+                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/_images/elura1.jpg',1)" checked="checked" type="radio">
                     </font></td>
                   <td colspan="2"><font size="-1"> The Elura ore body. Depth to top of gossan (in blue) is approximately 100 m.</font></td>
                 </tr>
                 <tr>
                   <td valign="top" width="10"><font size="-1"><b>b.</b> </font></td>
                   <td valign="top" width="10"><font size="-1">
-                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/en/latest/_images/elura2.jpg',1)" type="radio">
+                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/_images/elura2.jpg',1)" type="radio">
                     </font></td>
                   <td colspan="2"><font size="-1"> A DC resistivity survey involves injecting current at one location and measuring resulting potentials at another location.</font></td>
                 </tr>
                 <tr>
                   <td valign="top" width="10"><font size="-1"><b>c.</b> </font></td>
                   <td valign="top" width="10"><font size="-1">
-                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/en/latest/_images/elura3.jpg',1)" type="radio">
+                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/_images/elura3.jpg',1)" type="radio">
                     </font></td>
                   <td colspan="2"><font size="-1"> Current will flow. Current density increases within conductive regions, and decreases within resistive regions.&nbsp;</font></td>
                 </tr>
                 <tr>
                   <td valign="top" width="10"><font size="-1"><b>d.</b> </font></td>
                   <td valign="top" width="10"><font size="-1">
-                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/en/latest/_images/elura4.jpg',1)" type="radio">
+                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/_images/elura4.jpg',1)" type="radio">
                     </font></td>
                   <td colspan="2"><font size="-1"> Charges build up at interfaces between regions of different electrical conductivity.</font></td>
                 </tr>
                 <tr>
                   <td valign="top" width="10"><font size="-1"><b>e.</b> </font></td>
                   <td valign="top" width="10"><font size="-1">
-                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/en/latest/_images/elura5.jpg',1)" type="radio">
+                    <input name="direction" value="OFF" onclick="MM_swapImage('elura1','','http://gpg.geosci.xyz/_images/elura5.jpg',1)" type="radio">
                     </font></td>
                   <td colspan="2"><font size="-1"> Variations in charge distribution are detected as variations in distribution of potential, or voltage, at the surface.&nbsp; </font> </td>
                 </tr>
                 <tr>
                   <td width="10"><font size="-1">&nbsp;</font><br> </td>
                   <td width="10">&nbsp;</td>
-                  <td align="center" valign="CENTER" width="32%"><font size="-1"><img src="http://gpg.geosci.xyz/en/latest/_images/elura1.jpg" name="elura1" alt="Elura Orebody" height="292" width="225"> </font></td>
+                  <td align="center" valign="CENTER" width="32%"><font size="-1"><img src="http://gpg.geosci.xyz/_images/elura1.jpg" name="elura1" alt="Elura Orebody" height="292" width="225"> </font></td>
                   <td align="center" valign="top" width="56%"> <center>
                       <br>
                       <span class="caption">Elura Orebody Electrical resistivities</span>

--- a/content/geophysical_surveys/dcr/images/pseudosection_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/pseudosection_radio_buttons.html
@@ -37,14 +37,14 @@ function MM_preloadImages() { //v3.0
                         <tr valign="top">
                           <td>
                             <br>
-                            <input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('pseudoanim','','http://gpg.geosci.xyz/en/latest/_images/lawn-ps.gif',1)" type="radio">
+                            <input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('pseudoanim','','http://gpg.geosci.xyz/_images/lawn-ps.gif',1)" type="radio">
                             Finished pseudo-section.<br>
-                            <input name="radiobutton" value="radiobutton" checked="checked"  onclick="MM_swapImage('pseudoanim','','http://gpg.geosci.xyz/en/latest/_images/pseudo-anim.gif',1)" checked="checked" type="radio">
+                            <input name="radiobutton" value="radiobutton" checked="checked"  onclick="MM_swapImage('pseudoanim','','http://gpg.geosci.xyz/_images/pseudo-anim.gif',1)" checked="checked" type="radio">
                             Animation. <br>
                           </td>
                       </td>
                       <td style="width:80%;">
-                        <img src="http://gpg.geosci.xyz/en/latest/_images/pseudo-anim.gif" name="pseudoanim" alt="profiling concepts" border="0" width="100%"><br>
+                        <img src="http://gpg.geosci.xyz/_images/pseudo-anim.gif" name="pseudoanim" alt="profiling concepts" border="0" width="100%"><br>
                       </td>
                 </tr>
               </tbody>

--- a/content/geophysical_surveys/dcr/images/sounding_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/sounding_radio_buttons.html
@@ -49,20 +49,20 @@ function MM_preloadImages() { //v3.0
                         <tr valign="top">
                           <td>
                             <br>
-                            <input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv1.gif',1)" type="radio">
+                            <input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/_images/surv1.gif',1)" type="radio">
                               &nbsp At small electrode spacings current flows only in near-surface regions. Apparent resistivities look similar to the true resistivity of overburden.
                               <br><br>
-                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv2.gif',1)" type="radio">
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/_images/surv2.gif',1)" type="radio">
                               &nbsp As current flows deeper, apparent resistivities are influenced by the true resistivities of deeper materials.<br><br>
-                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv3.gif',1)" type="radio">
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/_images/surv3.gif',1)" type="radio">
                               &nbsp The sounding curve begins to indicate that there are at least 2 layers under this location.<br><br>
-                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv4.gif',1)" type="radio">
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/_images/surv4.gif',1)" type="radio">
                               &nbsp At very large electrode spacings most of the information reflects deeper ground because that is where most of the current is flowing.<br><br>
-                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/en/latest/_images/surv5.gif',1)" type="radio">
+                            <input name="radiobutton" value="radiobutton" onclick="MM_swapImage('sounding','','http://gpg.geosci.xyz/_images/surv5.gif',1)" type="radio">
                               &nbsp The completed sounding curve. <br><br>
                           </td>
 
-                          <td style="width:35%;"><img src="http://gpg.geosci.xyz/en/latest/_images/surv1.gif" name="sounding" width="100%">
+                          <td style="width:35%;"><img src="http://gpg.geosci.xyz/_images/surv1.gif" name="sounding" width="100%">
                           <br>
                           </td>
                         </tr>

--- a/content/geophysical_surveys/dcr/images/survey_radio_buttons.html
+++ b/content/geophysical_surveys/dcr/images/survey_radio_buttons.html
@@ -29,65 +29,65 @@ function MM_preloadImages() { //v3.0
  <table border="1" cellpadding="1" cellspacing="1" width="100%">
           <tbody>
             <tr>
-              <td><font size="-1"><img src="http://gpg.geosci.xyz/en/latest/_images/add1.gif" name="arrays" align="middle" height="74" width="300"> </font> <span class="caption">Common DC resistivity arrays </span>
+              <td><font size="-1"><img src="http://gpg.geosci.xyz/_images/add1.gif" name="arrays" align="middle" height="74" width="300"> </font> <span class="caption">Common DC resistivity arrays </span>
                 <form name="form1" method="post" action="">
                   <table align="center" border="1" cellpadding="2" cellspacing="0" width="98%">
                     <tbody>
                       <tr valign="top">
                         <td><strong>a.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/add1.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" checked="checked" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/add1.gif',1)" type="radio"></td>
                         <td rowspan="2"><b>dipole-dipole (dpdp)</b></td>
                         <td> Most common profiling configuration. </td>
                       </tr>
                       <tr valign="top">
                         <td><strong>b.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/add2.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/add2.gif',1)" type="radio"></td>
                         <td>Several potential measurements are taken for each transmitter station.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>c.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/apd.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/apd.gif',1)" type="radio"></td>
                         <td><b>pole-dipole (pldp)</b></td>
                         <td> Compared to dpdp, more efficient (move only one source electrode), deeper penetration, but lower spatial resolution.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>d.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/app.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/app.gif',1)" type="radio"></td>
                         <td><strong>pole-pole (plpl)</strong></td>
                         <td> Compared to pldp, more efficient, deeper penetration, but lower spatial resolution.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>e.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/ag.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/ag.gif',1)" type="radio"></td>
                         <td><b>gradient array</b></td>
                         <td> Poor depth information but rapid reconnaissance of large areas.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>f.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/ar.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/ar.gif',1)" type="radio"></td>
                         <td><b>Real section</b></td>
                         <td> Potential electrodes move along lines between current source electrodes.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>g.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/as1.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/as1.gif',1)" type="radio"></td>
                         <td rowspan="2"><b>Schlumberger sounding </b></td>
                         <td> Distance "a" is on the order of one tenth of distance "b".</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>h.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/as2.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/as2.gif',1)" type="radio"></td>
                         <td>For soundings, "b" can remain unchanged, as long as a &lt;&lt; b, and measured potentials are strong enough to record.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>i.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/aw1.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/aw1.gif',1)" type="radio"></td>
                         <td rowspan="2"><b>Wenner sounding </b></td>
                         <td> The three spacings between electrodes are kept equal for all measurements.</td>
                       </tr>
                       <tr valign="top">
                         <td><strong>j.</strong></td>
-                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/en/latest/_images/aw2.gif',1)" type="radio"></td>
+                        <td><input name="radiobutton" value="radiobutton" onclick="MM_swapImage('arrays','','http://gpg.geosci.xyz/_images/aw2.gif',1)" type="radio"></td>
                         <td>For soundings all electrodes must be moved for each new datum.</td>
                       </tr>
                     </tbody>

--- a/content/geophysical_surveys/dcr/index.rst
+++ b/content/geophysical_surveys/dcr/index.rst
@@ -9,7 +9,7 @@ Direct Current Resistivity
     vision for how it is applied in the field, and demonstrate potential uses.
 
 
-.. image:: http://gpg.geosci.xyz/en/latest/_images/icon_dc.gif
+.. image:: http://gpg.geosci.xyz/_images/icon_dc.gif
     :align: right
 
 Variations in :ref:`conductivity <electrical_conductivity_index>` can be

--- a/content/geophysical_surveys/dcr/survey.rst
+++ b/content/geophysical_surveys/dcr/survey.rst
@@ -19,15 +19,15 @@ Basic Survey Setup
 
         The basic DC resistivity array using 4 electrodes. A and B are the current electrodes while M and N are the potential electrodes. Distances between the electrodes are used to calculate :ref:`the geometry factor and apparent resistivity <dcr_data>`.
 
-       
+
 .. figure:: images/dcr_2dgeneral.png
         :name: dcr_2dgeneral
         :align: right
         :figwidth: 50%
 
         Schematic showing a general electrode layout in a grid. Each of the electrodes can be the current electrodes or the potential electrodes.
-        
-The basic DC resistivity (DCR) survey requires a generator that inputs electrical current into the ground and a voltmeter to measure the potential difference between two locations. The basic 4-electrode array is shown in :numref:`dcr_surv_5`. Various configurations of electrodes are possible. 
+
+The basic DC resistivity (DCR) survey requires a generator that inputs electrical current into the ground and a voltmeter to measure the potential difference between two locations. The basic 4-electrode array is shown in :numref:`dcr_surv_5`. Various configurations of electrodes are possible.
 
 The current waveform provided by the generator can be harmonic (for a frequency-domain survey), a full-duty bipolar pulse,  or a waveform composed of an "on-time" and "off-time".
 
@@ -48,16 +48,16 @@ There are many geometries of electrodes that can be used in the field. The elect
 Modern acquisition systems populate an area with electrodes and use different pairs as currents and potential electrodes. :numref:`dcr_2dgeneral` shows a general schematic showing electrode positions on a grid. Since each electrode can be a current or potential electrode, this electrode layout allows for a large set of measurements. It's generally not feasible, nor desirable, to collect all possible data. Arrays are selected to achieve specific goals. For instance:
 
 
-- Profiling: a fixed array is moved along a line. The data  provide information about lateral variations to a depth that is determined by the length of the array. 
+- Profiling: a fixed array is moved along a line. The data  provide information about lateral variations to a depth that is determined by the length of the array.
 
 - Sounding: a fixed geometry of electrodes is expanded symetrically about a central point of the array. The data provide information about how the electrical structure varies with depth. The data curve is often called a "sounding" and a single sounding can be inverted to produce a 1D conductivity model. If multiple soundings are available they can be inverted in 2D or 3D. The most common sounding configurations are the Wenner and Schlumberger arrays.
 
-- General configuration: These are combinations of profiling and sounding arrays. They are often obtained by defining an electrode array and expanding and translating it along a line. In practice, this is achieved by laying out a line of electrodes, each of which can be used as a current or potential electrode. The most common acquistion arrays are dipole-dipole, pole-dipole, or pole-pole arrays.  
+- General configuration: These are combinations of profiling and sounding arrays. They are often obtained by defining an electrode array and expanding and translating it along a line. In practice, this is achieved by laying out a line of electrodes, each of which can be used as a current or potential electrode. The most common acquistion arrays are dipole-dipole, pole-dipole, or pole-pole arrays.
 
 - Gradient array: This is a reconnaissance array that uses a fixed location for the A and B electrodes which are far apart. Measurements are taken in an area between the current electrodes. Potential differences in orthogonal directions can be acquired but usually only potential differences between electrodes aligned in the same direction as the A and B electrodes are obtained.
 
 Traditionally, data have been collected using co-linear electrodes. Depending upon the relative placement, the geometries have been given specific names. The interactive figure below shows how electrodes are placed for various named arrays. Electrodes placed on lines imply that the array is usually used for profiling. A circle at the array's center implies that the array is generally expanded symmetrically about its center for acquiring sounding data.
- 
+
 
 
 .. _dcr_survradiobuttons:
@@ -82,9 +82,9 @@ Traditionally, data have been collected using co-linear electrodes. Depending up
 
 **Three dimensional data acquisition**
 
-The general DCR problem can be stated as follows: Given a volume of the earth, collect DCR data and invert them to generate a 3D conductivity model. With modern technologies, data can be collected in three dimensions, using electrodes on the surface and in boreholes (:numref:`dcr_3dgeneral`). Any datum from a specific electrode placement produces some information but, as aquistion continues, some electrode placements may not provide new independent information. The choice of what data to collect is addressed in the section :ref:`Survey Design <dcr_survey_design>`. 
+The general DCR problem can be stated as follows: Given a volume of the earth, collect DCR data and invert them to generate a 3D conductivity model. With modern technologies, data can be collected in three dimensions, using electrodes on the surface and in boreholes (:numref:`dcr_3dgeneral`). Any datum from a specific electrode placement produces some information but, as aquistion continues, some electrode placements may not provide new independent information. The choice of what data to collect is addressed in the section :ref:`Survey Design <dcr_survey_design>`.
 
-Here we outline some basic principles about survey design and provide some acquistion strategies that are currently used. 
+Here we outline some basic principles about survey design and provide some acquistion strategies that are currently used.
 
 **Some basic principles for designing DCR Surveys**
 
@@ -94,12 +94,12 @@ Here we outline some basic principles about survey design and provide some acqui
 
 **Some general rules**
 
-For co-linear arrays, the depth of penetration depends upon the size of the array. 
-The depth to which significant current flows depends upon the distance between the source electrodes. 
+For co-linear arrays, the depth of penetration depends upon the size of the array.
+The depth to which significant current flows depends upon the distance between the source electrodes.
 A target at depth can be excited only when the current electrodes are significantly farther apart than the depth of the target.
 Since a datum is a potential difference, and since deeper targets are associated with smaller electrical charges (there's only small currents going through), detecting meaningful signal requires that the potential electrodes have significant separation.
 
-Assembling the above information leads to a general statement that depth of penetration progressively decreases as one proceeds from pole-pole, pole-dipole, to dipole-dipole. This is a reasonable rule of thumb and is applicable for surface arrays or for colinear arrays in borehole measurements. 
+Assembling the above information leads to a general statement that depth of penetration progressively decreases as one proceeds from pole-pole, pole-dipole, to dipole-dipole. This is a reasonable rule of thumb and is applicable for surface arrays or for colinear arrays in borehole measurements.
 
 **Some 3D Designs**
 
@@ -107,8 +107,8 @@ Some common 3D acquistion geometries are outlined below:
 
 - Multiple lines of co-linear acquisition, or offset acquistion: An example of a multiple line co-linear survey is shown in :numref:`dcr_colinear`. Off-line profiling involves moving the current electrodes along one survey line and recording potentials using electrodes planted along a different (usually parallel) line, as shown in :numref:`dcr_offset`
 
-- E-Scan: The E-Scan technique (:numref:`dcr_escan`) is a pole-pole configuration. However, it is organized by planting a large number of electrodes over the area of interest, without trying to stay on grid lines. One potential and one current electrode are placed at "infinity". When any electrode in the array is used as a current electrode, potentials at all other electrodes are measured. Each electrode, in turn, is used as a current. 
- 
+- E-Scan: The E-Scan technique (:numref:`dcr_escan`) is a pole-pole configuration. However, it is organized by planting a large number of electrodes over the area of interest, without trying to stay on grid lines. One potential and one current electrode are placed at "infinity". When any electrode in the array is used as a current electrode, potentials at all other electrodes are measured. Each electrode, in turn, is used as a current.
+
 - Cross-well survey: A cross-well survey is deployed in boreholes, usually using a minimum of 2 wells. Electrodes are positioned along the well and each can be a current or potential electrode. Current electrodes can be in the same well (along-well survey) or in different wells (cross-well survey). An example is shown in :numref:`dcr_crosswell`. For either current configuration, potentials can be measured in the same well or across wells.
 
 - Underground survey: DC resistivity surveys can also be conducted underground, such as in tunnels (:numref:`dcr_tunnel`). This restricts the survey configurations to be along the tunnel walls and ceilings but these geometries can still provide information about deep targets that may not be detectable from the surface.
@@ -160,14 +160,14 @@ Instrumentation
 
    A typical generator hooked up to a transmitter in the field. (Photo: Micahel McMillan)
 
-The following section provides some information about the instrumentation used in DC resistivity surveys and what's required for successful data collection. The instrumentation consists of transmitters, receivers, electrodes, and cables. The specific capabilities of these elements will vary depending upon intended use. In the material below we provide specifications that are relevant for a mid-sized mineral exploration project. 
+The following section provides some information about the instrumentation used in DC resistivity surveys and what's required for successful data collection. The instrumentation consists of transmitters, receivers, electrodes, and cables. The specific capabilities of these elements will vary depending upon intended use. In the material below we provide specifications that are relevant for a mid-sized mineral exploration project.
 
 .. _dcr_transmitters:
 
 **Transmitters:** A generator or battery provides a source of power for the transmitter in
 geophysical surveys. A typical example of a generator used for a DC survey would have a power limit of 7500W or
-greater. 
-For larger scale work, it is possible to obtain transmitters that can source up to 30,000 watts. 
+greater.
+For larger scale work, it is possible to obtain transmitters that can source up to 30,000 watts.
 The transmitter sends out a desired current waveform through the
 current wire. The electric current and voltage are measured and regulated by
 the transmitter controller, and either quantity can be set to a particular
@@ -179,9 +179,9 @@ half-duty waveform as shown in :numref:`dcr_txwave`. The name comes from the
 fact that the current is only running for half of the time. The figure shows
 that the current waveform has a two second positive on-time followed by a two-
 second off-time, followed by a two-second negative on-time before a final two
-second off-time (0.125 Hz). 
+second off-time (0.125 Hz).
 
-This waveform for the current source is necessary because a voltage measurement, when the current is off, will be non-zero in many situations. Naturally occuring potentials are called spontaneous or self potentials (SP), and they are usually caused by electrochemical activity in the ground or fields that arise from natural atmospheric or ionospheric sources.  From the point of view of DC resistivity surveys, SP voltages are noise.  The SP signals can be removed by using a bipolar waveform with a  50% duty cycle. Subtracting the responses of the two half-periods removes the SP provided that the SP signal doesn't vary significantly during one period of the waveform.  
+This waveform for the current source is necessary because a voltage measurement, when the current is off, will be non-zero in many situations. Naturally occuring potentials are called spontaneous or self potentials (SP), and they are usually caused by electrochemical activity in the ground or fields that arise from natural atmospheric or ionospheric sources.  From the point of view of DC resistivity surveys, SP voltages are noise.  The SP signals can be removed by using a bipolar waveform with a  50% duty cycle. Subtracting the responses of the two half-periods removes the SP provided that the SP signal doesn't vary significantly during one period of the waveform.
 
 .. figure:: images/txwave.gif
         :figwidth: 40%
@@ -197,7 +197,7 @@ This waveform for the current source is necessary because a voltage measurement,
    :align: right
    :name: IP_waveform
 
-..   A typical transmitter `waveform <http://gpg.geosci.xyz/en/latest/content/induced_polarization/induced_polarization_measurements_data.html>`_
+..   A typical transmitter `waveform <http://gpg.geosci.xyz/content/induced_polarization/induced_polarization_measurements_data.html>`_
 
 .. The primary voltage, or DC component of the measured voltage is taken before any IP effect has taken place, as noted by :math:`\mathrm{V}_{\sigma}` in :numref:`IP_waveform2`, whereas the IP measurement is taken as an integral beneath the voltage curve between two user defined time points (t1 and t2). The Newmont standard is to take t1 = 450 ms and t2 = 1100 ms.
 
@@ -206,14 +206,14 @@ This waveform for the current source is necessary because a voltage measurement,
    :align: right
    :name: IP_waveform2
 
-..   `Location of DC and IP measurements along the receiver voltage curve <http://gpg.geosci.xyz/en/latest/content/induced_polarization/induced_polarization_measurements_data.html>`_
+..   `Location of DC and IP measurements along the receiver voltage curve <http://gpg.geosci.xyz/content/induced_polarization/induced_polarization_measurements_data.html>`_
 
 .. _dcr_receivers:
 
 **Receivers:** Two receiver electrodes are used to measure the voltage difference in a DC
-survey. For DC resisitivity sounding, a simple digital volt meter can be adequate. A more complex system may involve amplifiers, filters, transmitter synchronizing circuits, display, storage, many inputs for simultaneous recording of many potentials, and other features. 
+survey. For DC resisitivity sounding, a simple digital volt meter can be adequate. A more complex system may involve amplifiers, filters, transmitter synchronizing circuits, display, storage, many inputs for simultaneous recording of many potentials, and other features.
 
-.. Synchronization with the transmitter is essential if IP data are to be gathered, but it is not critical if resistivity information only is to be obtained. IP receivers also must be capable of recording several signal strengths covering several orders of magnitude because signals while the transmitter is on may be several volts, while decay voltages during the transmitter's "off" time may be only a few micro or millivolts. 
+.. Synchronization with the transmitter is essential if IP data are to be gathered, but it is not critical if resistivity information only is to be obtained. IP receivers also must be capable of recording several signal strengths covering several orders of magnitude because signals while the transmitter is on may be several volts, while decay voltages during the transmitter's "off" time may be only a few micro or millivolts.
 
 .. figure:: images/receiver_electrode_porous_pots_receiver.jpg
    :figwidth: 40%
@@ -232,13 +232,13 @@ survey. For DC resisitivity sounding, a simple digital volt meter can be adequat
 
 .. _dcr_electrodes:
 
-**Electrodes:** In general, current injection and potential measurement electrodes are not interchangeable. However, automated acquisition systems using smaller source currents often employ the same stainless steel electrodes for a current electrode and a potential electrode. This becomes more difficult as the source current increases in strength because the ground can become altered by high current densities and the electrode can become polarized. 
+**Electrodes:** In general, current injection and potential measurement electrodes are not interchangeable. However, automated acquisition systems using smaller source currents often employ the same stainless steel electrodes for a current electrode and a potential electrode. This becomes more difficult as the source current increases in strength because the ground can become altered by high current densities and the electrode can become polarized.
 
 Current electrodes transmit electricity into the ground, and as such they need
-good contact with the ground, i.e., low impedance or small contact resistance. 
+good contact with the ground, i.e., low impedance or small contact resistance.
 Stainless steel stakes, sheets of foil, and wetted ground are all possible approaches to improving contact resistance.  Pouring salty water on the electrodes can help
 to improve the contact, or the electrode can be wrapped with a
-soaked cloth. 
+soaked cloth.
 
 For measuring potentials, low noise, non-polarizing (not necessarily low impedance) electrodes are sought after. Small lead plates buried in the soil will often help achieve this. In more difficult situations, wet electrodes made from porous ceramic jars containing salt solutions are required. It is also common to use lead wire in a lead-chloride mix or copper wire in a copper-sulphate solution. This eliminates
 self potential between the wire and the ground and improves the quality of

--- a/content/geophysical_surveys/fundamentals/seven_steps.rst
+++ b/content/geophysical_surveys/fundamentals/seven_steps.rst
@@ -9,7 +9,7 @@ effectively carried out by following a seven-step framework. Careful thought
 and due dilligence at each step is important to achieve a final outcome.
 
 
-.. figure:: http://gpg.geosci.xyz/en/latest/_images/seven_steps.jpg
+.. figure:: http://gpg.geosci.xyz/_images/seven_steps.jpg
     :align: center
     :width: 80 %
 

--- a/content/maxwell2_dc/fields_from_grounded_sources_dcr/effects_of_topography.rst
+++ b/content/maxwell2_dc/fields_from_grounded_sources_dcr/effects_of_topography.rst
@@ -141,7 +141,7 @@ problem that we derived in Section :ref:`effects_of_topography_electric_potentia
 proceed with this validation, we consider a pole transmitter injected in the
 ground. In the above figure, injected current source location is shown.
 
-.. _DC sphere code: https://github.com/ubcgif/em_examples/blob/master/util_codes/DCsphere.py
+.. _DC sphere code: https://github.com/ubcgif/em_examples/blob/master/em_examples/DCsphere.py
 
 For numerical computations, a 3D mesh with 5 m core cells is used. We compute
 potentials in every cells in the 3D domain. Top and middle panels of the below

--- a/content/maxwell2_dc/fields_from_grounded_sources_dcr/point_current_source_and_sphere.rst
+++ b/content/maxwell2_dc/fields_from_grounded_sources_dcr/point_current_source_and_sphere.rst
@@ -44,7 +44,7 @@ electric potential :math:`\phi` can be obtained by integrating the
 electric field from :math:`R` to :math:`\infty`. By substituting Ohm’s
 law (:math:`\vec E = \rho \vec J`) into the path integral:
 
-.. math:: 
+.. math::
    \phi = - \int_R^\infty \vec E \cdot d\vec l = - \int_R^\infty \frac{\rho I}{4 \pi r^2} dr = \frac{\rho I}{4\pi R}
 
 For reasons which will becomes apparent in the next section, we would
@@ -53,7 +53,7 @@ like to re-express :math:`\phi` in terms of a radial coordinate system
 the points which represent the problem geometry do not necessarily form
 a right-triangle, :math:`R` must be expressed using the cosine law:
 
-.. math:: 
+.. math::
    R = \sqrt{x_0^2 + r^2 - 2rx_0 cos \theta \;}
 
 For solutions where :math:`r<x_0`, :math:`1/R` can be split into a sum
@@ -162,7 +162,7 @@ Eq. :eq:`Potential_Sphere_WholeSpace` can be split into two terms: the potential
 Eq. :eq:`PsiWholespace2`, and an anomalous potential which results from the exstence of a
 conducting sphere. Python code functions which evaluate above solution is given at `DC sphere code`_.
 
-.. _DC sphere code: https://github.com/ubcgif/em_examples/blob/master/util_codes/DCsphere.py
+.. _DC sphere code: https://github.com/ubcgif/em_examples/blob/master/em_examples/DCsphere.py
 
 .. figure:: ../images/SphericalDepression_Sphere.png
    :align: center


### PR DESCRIPTION
- Within em_examples, the directory `util_codes` has been re-named `em_examples` in ubcgif/em_examples#20
- when we moved the gpg over to google app engine, the urls changed - we no longer have the `/en/latest/`, so gpg links have been updated accordingly 