### PR TITLE
Barents Sea Case History 

### DIFF
--- a/content/case_histories/balboa/synthesis.rst
+++ b/content/case_histories/balboa/synthesis.rst
@@ -29,7 +29,7 @@ electromagnetics.
     :name: ztemsyn2dinv
 
     ZTEM 2D synthetic modeling: a) 2D resistivity model for a porphyry body,
-    resembling Balboa, buried below 30m of conductive saprolite (30 Ω-m), and
+    resembling Balboa, buried below 30m of conductive saprolite (30 :math:`\Omega`-m), and
     b) 2D inversion of synthetic ZTEM data from model in
     :numref:`ztemsyn2dinv` a.
 

--- a/content/case_histories/hoop_region_norway/processinginterpretation.rst
+++ b/content/case_histories/hoop_region_norway/processinginterpretation.rst
@@ -24,7 +24,7 @@ The CSEM analysis was focused on line 5001. A 2.5D inversion approach, in which 
     :figwidth: 100%
     :name: fig_CSEM_amplitude_phase
 
-    CSEM Amplitude (top) and phase (bottom) data collected at 1Hz along line 5001. The effect of the oil accumulation at Wisting Central (around 611km Eastings) is clear, especially in the phase data. 
+    CSEM Amplitude (top) and phase (bottom) data collected at 1Hz along line 5001. The effect of the oil accumulation at Wisting Central (around 611km Eastings) is clear, especially in the phase data.
 
 
 The CSEM data for six frequencies (0.2Hz, 0.8Hz, 1Hz, 1.4Hz, 2.2Hz, 2.6Hz) were inverted using an Occam approach (:cite:`Constable1987,Key2014`) to derive anisotropic resistivity models that are smooth in a first derivative sense, and therefore as close to a uniform halfspace as possible, while honoring the data. A layered seawater conductivity structure based on measurements throughout the water column and 1D modeling was used. Nineteen to twenty-three source-receiver pairs per frequency were included in inversion.
@@ -50,13 +50,13 @@ The inversion was performed in stages. Firstly, an unconstrained inversion was r
 
 
 
-:numref:`fig_inversion_vertical_resistivity` shows the vertical (upper panel) and horizontal (lower panel) resistivity resulting from the final constrained inversion that were carried using depth-converted seismic horizons top St |lo| horizon and Intra-Snadd horizon. 
+:numref:`fig_inversion_vertical_resistivity` shows the vertical (upper panel) and horizontal (lower panel) resistivity resulting from the final constrained inversion that were carried using depth-converted seismic horizons top St |lo| horizon and Intra-Snadd horizon.
 
 
 Background resistivity is extremely high in the area with vertical resistivity of 25-30 |O| m. Background anisotropy is also extremely high with factors of five or more observed. This high overburden resistivity and anisotropy is the result of the significant uplift in the area. A significant increase in vertical resistivity was recovered in the lower Snadd, with localized variations contained within a regional feature. This regional feature also exhibits extremely high electrical anisotropy.
 
 
-A localized resistive feature coincident with the structure penetrated at Wisting Central is clearly recovered in the vertical resistivity. A more subtle increase in resistivity is observed at the Hanssen well location. No localized resistive feature is recovered in the St |lo| at the location of the Wisting Alternative or Bjaaland wells. 
+A localized resistive feature coincident with the structure penetrated at Wisting Central is clearly recovered in the vertical resistivity. A more subtle increase in resistivity is observed at the Hanssen well location. No localized resistive feature is recovered in the St |lo| at the location of the Wisting Alternative or Bjaaland wells.
 
 
 :numref:`fig_hydrocarbon_saturation` shows the CSEM-derived vertical resistivity in the same windows of analysis used in the seismic quantitative interpretation, for the unconstrained and constrained inversions run: The top one corresponding to the unconstrained inversion, and the bottom image shows the results of the constrained inversion previously shown in the :numref:`fig_inversion_vertical_resistivity`.
@@ -163,10 +163,13 @@ An analysis of :numref:`fig_transverse_resistivity_compare` a offers important i
     :figwidth: 100%
     :name: fig_transverse_resistivity_compare
 
-a) Comparison between the seismically- and CSEM-derived transverse resistance estimates.
-b) Cross-section along A-A' (:numref:`fig_geology_region_map_setup`) of seismically-derived resistivity for :math:`Sw` = 0.1.
-c) Same cross-section along A-A' for :math:`Sw` = 0.5.
-d) Same cross-section along A-A' for :math:`Sw` = 1. Note the good match between the measured and modeled resistivity in the Central well at the (b) section.
+    (a) Comparison between the seismically- and CSEM-derived transverse
+    resistance estimates. (b) Cross-section along A-A'
+    (:numref:`fig_geology_region_map_setup`) of seismically-derived
+    resistivity for :math:`Sw` = 0.1. (c) Same cross-section along A-A' for
+    :math:`Sw` = 0.5. (d) Same cross-section along A-A' for :math:`Sw` = 1.
+    Note the good match between the measured and modeled resistivity in the
+    Central well at the (b) section.
 
 
 

--- a/content/case_histories/hoop_region_norway/properties.rst
+++ b/content/case_histories/hoop_region_norway/properties.rst
@@ -96,7 +96,14 @@ In the context of a CSEM analysis, the background resistivity and the contrast b
     :figwidth: 100%
     :name: fig_well_log_resistivity
 
-    (a) Well log suite from the Wisting Alternative well, showing porosity, lithology, :math:`Sw` *and resistivity.
-    (b) Well log suite from the Wisting Central well, showing porosity, lithology, :math:`Sw` *and resistivity.
-    (c) The variation of resistivity with water saturation calculated from the Wisting Central and Alternative wells using the Simandoux equation. The shaded region shows the area in which the resistivity of the reservoir is less than the resistivity of the background structure, and will not be detected by a CSEM survey. Water saturations less than about 30% are required for the reservoir to be detected.
+    (a) Well log suite from the Wisting Alternative well, showing porosity,
+    lithology, :math:`Sw` *and resistivity. (b) Well log suite from the
+    Wisting Central well, showing porosity, lithology, :math:`Sw` *and
+    resistivity. (c) The variation of resistivity with water saturation
+    calculated from the Wisting Central and Alternative wells using the
+    Simandoux equation. The shaded region shows the area in which the
+    resistivity of the reservoir is less than the resistivity of the
+    background structure, and will not be detected by a CSEM survey. Water
+    saturations less than about 30% are required for the reservoir to be
+    detected.
 

--- a/content/case_histories/hoop_region_norway/properties.rst
+++ b/content/case_histories/hoop_region_norway/properties.rst
@@ -26,8 +26,12 @@ Two important observations can be extracted from these plots. The first is the w
     :figwidth: 80%
     :name: fig_poisson_acoustic_impedance
 
-a) *For the St* |lo| *Fm., multi-well cross-plot of Poisson’s ratio versus acoustic impedance color coded by fluid saturation with background colored by volume of clay for the full well.*
-b) *For the Nordmela Fm., multi-well cross-plot of Poisson’s ratio versus acoustic impedance color coded by fluid saturation with background colored by volume of clay for the full well.*
+    (a) For the St |lo| Fm., multi-well cross-plot of Poisson’s ratio versus
+    acoustic impedance color coded by fluid saturation with background
+    colored by volume of clay for the full well. (b) For the Nordmela Fm.,
+    multi-well cross-plot of Poisson’s ratio versus acoustic impedance color
+    coded by fluid saturation with background colored by volume of clay for
+    the full well.
 
 
 .. figure:: images/resistivity_vs_acoustic_impedance.png
@@ -35,11 +39,18 @@ b) *For the Nordmela Fm., multi-well cross-plot of Poisson’s ratio versus acou
     :figwidth: 80%
     :name: fig_resistivity_acoustic_impedance
 
-a) *For the St* |lo| *Fm., multi-well cross-plot of acoustic impedance versus resistivity color coded by fluid saturation with background colored by volume of clay for the full well.*
-b) *For the Nordmela Fm., multi-well cross-plot of acoustic impedance versus resistivity color coded by fluid saturation with background colored by volume of clay for the full well. The induction in situ resistivity in Central is clipped at 1,000 Ωm in the St* |lo| *sands, for reference the laterolog shows a similar shape in this zone, but is clipped at 100,000 Ωm.*
+    (a) For the St |lo| Fm., multi-well cross-plot of acoustic impedance
+    versus resistivity color coded by fluid saturation with background
+    colored by volume of clay for the full well. (b) For the Nordmela Fm.,
+    multi-well cross-plot of acoustic impedance versus resistivity color
+    coded by fluid saturation with background colored by volume of clay for
+    the full well. The induction in situ resistivity in Central is clipped at
+    1,000 :math:`\Omega m` in the St* |lo| *sands, for reference the
+    laterolog shows a similar shape in this zone, but is clipped at 100,000
+    :math:`\Omega m`.
 
 
-There is significant variation between the resistivity measurements made with different tools in the well.  In order to calibrate the saturation model we have chosen to use the LWD P40H curve. This is from a phase shift induction tool, logged while drilling (which has the added benefit of reducing the impact of mud invasion). This tool has returned results that are closer in amplitude to the CSEM derived resistivity values, when compared to the wireline HRLT laterolog results (with resistivities in the tens of thousands Ωm). With the chosen induction curve resistivity values in the St |lo| Fm. at Wisting Central are in the 700-900 Ωm range. The water saturation was calculated from this using the rock physics model represented by the Simandoux equation (:cite:`Simandoux1963`), Eq. :eq:`eq_Simandoux`, due to the overall simplicity of the model and increased accuracy over Archie in shaly-sand systems. This gives predicted hydrocarbon saturations in excess of 90%.
+There is significant variation between the resistivity measurements made with different tools in the well.  In order to calibrate the saturation model we have chosen to use the LWD P40H curve. This is from a phase shift induction tool, logged while drilling (which has the added benefit of reducing the impact of mud invasion). This tool has returned results that are closer in amplitude to the CSEM derived resistivity values, when compared to the wireline HRLT laterolog results (with resistivities in the tens of thousands :math:`\Omega m`). With the chosen induction curve resistivity values in the St |lo| Fm. at Wisting Central are in the 700-900 :math:`\Omega m` range. The water saturation was calculated from this using the rock physics model represented by the Simandoux equation (:cite:`Simandoux1963`), Eq. :eq:`eq_Simandoux`, due to the overall simplicity of the model and increased accuracy over Archie in shaly-sand systems. This gives predicted hydrocarbon saturations in excess of 90%.
 
 
 .. math::
@@ -53,7 +64,7 @@ where :math:`R_t` is the horizontal resistivity, :math:`Sw` is the water saturat
 .. math::
 	\phi_e = \phi_T \times (1 - Vsh)
     :name: eq_Simandoux_phi
- 
+
 
 where :math:`\phi_T` is the total porosity. The parameters used in the Simandoux equation were calibrated to the measured data and are summarized in the following table.
 
@@ -77,7 +88,7 @@ Table 1. *Parameters used in the Simandoux equation.*
 
 
 
-In the context of a CSEM analysis, the background resistivity and the contrast between background and reservoir is also important to understand. :numref:`fig_well_log_resistivity` a and :numref:`fig_well_log_resistivity` b show the resistivity variation with saturation calculated at the Wisting Central and Alternative wells using the Simandoux parameters from table 1. For each case, the calibrated Simandoux equation is used to calculate the resistivity at log scale for a range of values of :math:`Sw` (:numref:`fig_well_log_resistivity` c). The log scale values are then up-scaled using an arithmetic average to give the bulk vertical resistivity (as would be measured by a CSEM survey) across the reservoir interval. The shaded area corresponds to the region of the curve where the resistivity is equal to or lower than the observed background vertical resistivity in the area (around 20-30 |O| m). Only when the reservoir resistivity lies outside the shaded region is there a contrast between it and the background, allowing it to be detected by a CSEM survey. :numref:`fig_well_log_resistivity` c shows that this condition is met for values of :math:`Sw` less than 30%. This provides a practical limit on the sensitivity to :math:`Sw`, i.e. values greater than this will not be resolved. 
+In the context of a CSEM analysis, the background resistivity and the contrast between background and reservoir is also important to understand. :numref:`fig_well_log_resistivity` a and :numref:`fig_well_log_resistivity` b show the resistivity variation with saturation calculated at the Wisting Central and Alternative wells using the Simandoux parameters from table 1. For each case, the calibrated Simandoux equation is used to calculate the resistivity at log scale for a range of values of :math:`Sw` (:numref:`fig_well_log_resistivity` c). The log scale values are then up-scaled using an arithmetic average to give the bulk vertical resistivity (as would be measured by a CSEM survey) across the reservoir interval. The shaded area corresponds to the region of the curve where the resistivity is equal to or lower than the observed background vertical resistivity in the area (around 20-30 |O| m). Only when the reservoir resistivity lies outside the shaded region is there a contrast between it and the background, allowing it to be detected by a CSEM survey. :numref:`fig_well_log_resistivity` c shows that this condition is met for values of :math:`Sw` less than 30%. This provides a practical limit on the sensitivity to :math:`Sw`, i.e. values greater than this will not be resolved.
 
 
 .. figure:: images/well_log_resistivity.png
@@ -85,17 +96,7 @@ In the context of a CSEM analysis, the background resistivity and the contrast b
     :figwidth: 100%
     :name: fig_well_log_resistivity
 
-a) *Well log suite from the Wisting Alternative well, showing porosity, lithology,* :math:`Sw` *and resistivity.*
-b) *Well log suite from the Wisting Central well, showing porosity, lithology,* :math:`Sw` *and resistivity.*
-c) *The variation of resistivity with water saturation calculated from the Wisting Central and Alternative wells using the Simandoux equation. The shaded region shows the area in which the resistivity of the reservoir is less than the resistivity of the background structure, and will not be detected by a CSEM survey. Water saturations less than about 30% are required for the reservoir to be detected.*
-
-
-
-
-
-
-
-
-
-
+    (a) Well log suite from the Wisting Alternative well, showing porosity, lithology, :math:`Sw` *and resistivity.
+    (b) Well log suite from the Wisting Central well, showing porosity, lithology, :math:`Sw` *and resistivity.
+    (c) The variation of resistivity with water saturation calculated from the Wisting Central and Alternative wells using the Simandoux equation. The shaded region shows the area in which the resistivity of the reservoir is less than the resistivity of the background structure, and will not be detected by a CSEM survey. Water saturations less than about 30% are required for the reservoir to be detected.
 

--- a/content/case_histories/hoop_region_norway/properties.rst
+++ b/content/case_histories/hoop_region_norway/properties.rst
@@ -45,7 +45,7 @@ Two important observations can be extracted from these plots. The first is the w
     multi-well cross-plot of acoustic impedance versus resistivity color
     coded by fluid saturation with background colored by volume of clay for
     the full well. The induction in situ resistivity in Central is clipped at
-    1,000 :math:`\Omega m` in the St* |lo| *sands, for reference the
+    1,000 :math:`\Omega m` in the St |lo| sands, for reference the
     laterolog shows a similar shape in this zone, but is clipped at 100,000
     :math:`\Omega m`.
 
@@ -97,8 +97,8 @@ In the context of a CSEM analysis, the background resistivity and the contrast b
     :name: fig_well_log_resistivity
 
     (a) Well log suite from the Wisting Alternative well, showing porosity,
-    lithology, :math:`Sw` *and resistivity. (b) Well log suite from the
-    Wisting Central well, showing porosity, lithology, :math:`Sw` *and
+    lithology, :math:`Sw` and resistivity. (b) Well log suite from the
+    Wisting Central well, showing porosity, lithology, :math:`Sw` and
     resistivity. (c) The variation of resistivity with water saturation
     calculated from the Wisting Central and Alternative wells using the
     Simandoux equation. The shaded region shows the area in which the

--- a/content/case_histories/hoop_region_norway/setup.rst
+++ b/content/case_histories/hoop_region_norway/setup.rst
@@ -76,7 +76,7 @@ The study area is significantly uplifted, and characterized by high background r
     :figwidth: 100%
     :name: fig_cross_section_seismic
 
-    *Seismic cross-section through though the wells Alternative and Central. The top St* |lo| *horizon marks the top of the reservoir interval encountered in the Wisting Central well (7324/8-1).*
+    Seismic cross-section through though the wells Alternative and Central. The top St |lo| horizon marks the top of the reservoir interval encountered in the Wisting Central well (7324/8-1).
 
 
 

--- a/content/case_histories/hoop_region_norway/setup.rst
+++ b/content/case_histories/hoop_region_norway/setup.rst
@@ -36,10 +36,10 @@ Nowadays the integration of pre-stack seismic inversion attributes with CSEM att
 However, there are a number of challenges to be overcome when putting seismic and CSEM data together. Electric and elastic properties must be coupled through a single earth model that accurately and consistently describes each. There must be overlap in sensitivity of the methods applied to the properties within the intervals of interest. Finally, seismic, CSEM and well log data sample the earth at very different scales, which must be reconciled in an integrated interpretation.
 
 
-The integration process itself can take many forms. The simplest qualitative techniques, such as co-rendering, are applicable everywhere and provide a first-look approach to data combination. However, they can be misleading since they fail to address the underlying cause of variations observed. Full quantitative joint inversion of seismic and CSEM data is in principle possible (for example :cite:`Chen2012,Du2010`), but is complex and applicable in a far narrower range of circumstances. An intermediate approach, based on a sequential quantitative integrated interpretation workflow, which seeks to integrate elastic and electric attributes derived from inversion of seismic and CSEM data respectively, provides in many circumstances an effective way of addressing the challenges of data integration. 
+The integration process itself can take many forms. The simplest qualitative techniques, such as co-rendering, are applicable everywhere and provide a first-look approach to data combination. However, they can be misleading since they fail to address the underlying cause of variations observed. Full quantitative joint inversion of seismic and CSEM data is in principle possible (for example :cite:`Chen2012,Du2010`), but is complex and applicable in a far narrower range of circumstances. An intermediate approach, based on a sequential quantitative integrated interpretation workflow, which seeks to integrate elastic and electric attributes derived from inversion of seismic and CSEM data respectively, provides in many circumstances an effective way of addressing the challenges of data integration.
 
 
-This paper presents a case study in which the latter integration approach has been applied to overcome the challenges of the integration of seismic and CSEM data and successfully predicts a seismic-resolution fluid saturation volume that helps characterize the reservoir and diminish the risk related to the exploration and appraisal of the prospects in the study area. The area in question covers a significant oil discovery in the Hoop Fault Complex on the Bjarmeland Platform in the Barents Sea, Norway (:numref:`fig_geology_region_map_setup` a). 
+This paper presents a case study in which the latter integration approach has been applied to overcome the challenges of the integration of seismic and CSEM data and successfully predicts a seismic-resolution fluid saturation volume that helps characterize the reservoir and diminish the risk related to the exploration and appraisal of the prospects in the study area. The area in question covers a significant oil discovery in the Hoop Fault Complex on the Bjarmeland Platform in the Barents Sea, Norway (:numref:`fig_geology_region_map_setup` a).
 
 
 .. figure:: images/geology_region_map.png
@@ -47,8 +47,14 @@ This paper presents a case study in which the latter integration approach has be
     :figwidth: 100%
     :name: fig_geology_region_map_setup
 
-a) *Structural elements of the Barents Seas showing with a red box the location of the studied area* (:cite:`Halland2013`).
-b) *Detailed view of the studied area showing the location of the 2D GeoStreamer* |Res| *seismic and towed streamer CSEM data (blue lines), as well as the calibration well (Central and Alternative) and the validation wells (Hanssen and Bjaaland). The green outlines show the location of the proven reservoirs in the area (data courtesy of NPD), which were discovered by the wells Central and Hanssen.*
+    Geologic Setting. (a) Structural elements of the Barents Seas showing with
+    a red box the location of the studied area (:cite:`Halland2013`). (b)
+    Detailed view of the studied area showing the location of the 2D
+    GeoStreamer |Res| seismic and towed streamer CSEM data (blue lines), as
+    well as the calibration well (Central and Alternative) and the validation
+    wells (Hanssen and Bjaaland). The green outlines show the location of the
+    proven reservoirs in the area (data courtesy of NPD), which were
+    discovered by the wells Central and Hanssen.
 
 
 
@@ -62,7 +68,7 @@ Several sedimentary basins and platform areas make up the Norwegian sector of th
 The Realgrunnen Subgroup of the Kapp Toscana Group provides some of the best reservoirs in the Barents Sea. It is subdivided into four formations: Fruholmen, Tub |ao| en, Nordmela and St |o|. The Nordmela Formation (Sinemurian-Late Pliensbachian) consists of interbedded siltstones, sandstones, shale and mudstones with minor coals. Sandstones become more common towards the top. The formation represents deposits in a tidal flat to flood-plain environment. Individual sandstones represent estuarine and tidal channels. The St |lo| Formation (Late Pliensbachian to Bajocian) is defined with the appearance of sandy sequences above the shale-dominated sediments of the Nordmela Formation. The dominant lithology of the St |lo| Formation is mineralogically mature and well sorted sandstone. The sands in the St |lo| Formation were deposited in prograding coastal regimes, and a variety of linear clastic coast lithofacies are represented. Marked shale and siltstone intervals represent regional transgressive pulses in the late Toarcian and late Aalenian. Overlying the St |lo| Formation is the Fuglen Formation, which belongs to the Adventdalen Group. The group is dominated by dark marine mudstones, locally including deltaic and shelf sandstones as well as carbonate. The Fuglen Formation constitutes the cap rocks of the reservoir facies (:cite:`Halland2013`).
 
 
-The study area is significantly uplifted, and characterized by high background resistivity and high electrical anisotropies. Target intervals exist in a wide range of depths, ranging from about 250m below mudline to nearly 2000m below mudline. The reservoir encountered in well 7324/8-1(Wisting Central) consists of the St |lo| and Nordmela Formations, overlying the Snadd Fm. of upper Triassic age. The St |lo| Fm. is marked by a sharp contact with the overlying Fuglen Fm., seen both on logs and on drilling parameters. The St |lo| Fm. consists of 20m clean and homogenous sand, with very good reservoir properties. This is confirmed both by wireline log data and core measurements. 
+The study area is significantly uplifted, and characterized by high background resistivity and high electrical anisotropies. Target intervals exist in a wide range of depths, ranging from about 250m below mudline to nearly 2000m below mudline. The reservoir encountered in well 7324/8-1(Wisting Central) consists of the St |lo| and Nordmela Formations, overlying the Snadd Fm. of upper Triassic age. The St |lo| Fm. is marked by a sharp contact with the overlying Fuglen Fm., seen both on logs and on drilling parameters. The St |lo| Fm. consists of 20m clean and homogenous sand, with very good reservoir properties. This is confirmed both by wireline log data and core measurements.
 
 
 .. figure:: images/cross_section_seismic.png

--- a/content/case_histories/hoop_region_norway/surveydata.rst
+++ b/content/case_histories/hoop_region_norway/surveydata.rst
@@ -22,7 +22,7 @@ A densely sampled dataset consisting of six lines of 2D seismic and towed stream
 In general, the 2D seismic data quality is good but varies significantly in different parts of the survey.  The velocity fields obtained from the fast track migration of the data available at the time of this study were not sufficiently accurate to completely flatten and position events properly. The data were therefore conditioned before use in the workflow described here following the approach described by Singleton :cite:`Singleton2009`).
 
 
-For the CSEM data acquisition, a towed streamer consisting of 72 receivers collected data at source-receiver offsets ranging from 31 to 7755m. Overall, quality of the data used in the study was excellent, with good signal to noise ratios over a wide range of frequencies between 0.2Hz to over 3Hz. The remainder of this case study will address the analysis of the data from line 5001P1009, which provides the best calibration with the well information available in the area (:numref:`fig_geology_region_map_2` b). 
+For the CSEM data acquisition, a towed streamer consisting of 72 receivers collected data at source-receiver offsets ranging from 31 to 7755m. Overall, quality of the data used in the study was excellent, with good signal to noise ratios over a wide range of frequencies between 0.2Hz to over 3Hz. The remainder of this case study will address the analysis of the data from line 5001P1009, which provides the best calibration with the well information available in the area (:numref:`fig_geology_region_map_2` b).
 
 
 .. figure:: images/geology_region_map.png
@@ -30,7 +30,14 @@ For the CSEM data acquisition, a towed streamer consisting of 72 receivers colle
     :figwidth: 100%
     :name: fig_geology_region_map_2
 
-a) *Structural elements of the Barents Seas showing with a red box the location of the studied area (modified from Halland et al.* :cite:`Halland2013` *).*
-b) *Detailed view of the studied area showing the location of the 2D GeoStreamer* |Res| *seismic and towed streamer CSEM data (blue lines), as well as the calibration well (Central and Alternative) and the validation wells (Hanssen and Bjaaland). The green outlines show the location of the proven reservoirs in the area (data courtesy of NPD), which were discovered by the wells Central and Hanssen.*
+    (a) Structural elements of the Barents Seas showing with a red box the
+    location of the studied area (modified from Halland et al.
+    :cite:`Halland2013` ). (b) Detailed view of the studied area showing
+    the location of the 2D GeoStreamer |Res| seismic and towed streamer
+    CSEM data (blue lines), as well as the calibration well (Central and
+    Alternative) and the validation wells (Hanssen and Bjaaland). The green
+    outlines show the location of the proven reservoirs in the area (data
+    courtesy of NPD), which were discovered by the wells Central and
+    Hanssen.
 
 


### PR DESCRIPTION
- indent figure caption so figure numbers are displayed
- use `` :math:`\Omega` `` for units of resistivity
- [ ] Still outstanding are the equations that are not being properly numbered as per #366 

@dccowan : can you take a look at these changes and merge this in if you are happy. Also, if you are able to address the missing equations, that would be a huge help! Please let me know if anything is unclear. 

cc @dougoldenburg 

![image](https://cloud.githubusercontent.com/assets/6361812/20742807/5fb5afa6-b687-11e6-8028-19ea80530f2c.png)

![image](https://cloud.githubusercontent.com/assets/6361812/20742923/322758c2-b688-11e6-83b6-b20ee14f2820.png)
