### PR TITLE
pin sphinx version to 1.4.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 ipython
 ipywidgets
-sphinx
+sphinx==1.4.8
 matplotlib
 properties
 sphinxcontrib-bibtex


### PR DESCRIPTION
- pin sphinx version to 1.4.8 until I can patch the way equations are referenced. 